### PR TITLE
Fix SQLiteConstraintException with non-unique Insert

### DIFF
--- a/app/src/main/java/de/tum/in/tumcampusapp/component/notifications/persistence/ActiveAlarmsDao.kt
+++ b/app/src/main/java/de/tum/in/tumcampusapp/component/notifications/persistence/ActiveAlarmsDao.kt
@@ -1,14 +1,11 @@
 package de.tum.`in`.tumcampusapp.component.notifications.persistence
 
-import android.arch.persistence.room.Dao
-import android.arch.persistence.room.Delete
-import android.arch.persistence.room.Insert
-import android.arch.persistence.room.Query
+import android.arch.persistence.room.*
 
 @Dao
 interface ActiveAlarmsDao {
 
-    @Insert
+    @Insert(onConflict = OnConflictStrategy.IGNORE)
     fun addActiveAlarm(alarm: ActiveAlarm)
 
     @Delete


### PR DESCRIPTION
When an Alarm is already active, just ignore it when we're setting it as active again.

Just noticed this obvious crash in the recent 2.2 release. @kordianbruck seems to be trigger happy with non-beta releases :laughing:

@kordianbruck could you cherry-pick this and release a 2.2.1 as soon as possible?