### PR TITLE
Fixing case for 'TU Film' string.

### DIFF
--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -101,7 +101,6 @@
     <string name="info_title">Neuigkeiten:</string>
 
     <!-- Kino -->
-    <string name="kino">TU Kino</string>
     <string name="imdb_rating">IMDb-Wertung</string>
     <string name="year">Erscheinungsjahr</string>
     <string name="runtime">Laufzeit</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -317,7 +317,7 @@
     <string name="closed">Closed</string>
 
     <!-- Kino -->
-    <string name="kino">TU Film</string>
+    <string name="kino" translatable="false">tu film</string>
     <string name="imdb_rating">IMDb-Rating</string>
     <string name="year">Year of release</string>
     <string name="runtime">Runtime</string>


### PR DESCRIPTION
Making sure German and English has same translation.

## Issue
[Case 1180](https://github.com/TUM-Dev/Campus-Android/issues/1180)

This fixes the following issue(s):

Correct casing and makes translation same for TU Film.



