### PR TITLE
TicketSale: hide past events

### DIFF
--- a/app/src/main/java/de/tum/in/tumcampusapp/component/ui/ticket/EventDao.java
+++ b/app/src/main/java/de/tum/in/tumcampusapp/component/ui/ticket/EventDao.java
@@ -1,20 +1,19 @@
 package de.tum.in.tumcampusapp.component.ui.ticket;
 
+import java.util.List;
+
 import androidx.lifecycle.LiveData;
 import androidx.room.Dao;
 import androidx.room.Insert;
 import androidx.room.OnConflictStrategy;
 import androidx.room.Query;
-
-import java.util.List;
-
 import de.tum.in.tumcampusapp.component.ui.ticket.model.Event;
 
 @Dao
 public interface EventDao {
 
-    @Query("SELECT * FROM events ORDER BY start_time")
-    LiveData<List<Event>> getAll();
+    @Query("SELECT * FROM events WHERE start_time > date('now') ORDER BY start_time")
+    LiveData<List<Event>> getAllFutureEvents();
 
     @Query("SELECT * FROM events WHERE start_time > date('now') ORDER BY start_time LIMIT 1")
     Event getNextEvent();

--- a/app/src/main/java/de/tum/in/tumcampusapp/component/ui/ticket/EventDao.java
+++ b/app/src/main/java/de/tum/in/tumcampusapp/component/ui/ticket/EventDao.java
@@ -27,7 +27,7 @@ public interface EventDao {
     @Query("UPDATE events SET dismissed = 1 WHERE id = :eventId")
     void setDismissed(int eventId);
 
-    @Query("DELETE FROM events WHERE start_time < date('now')")
+    @Query("DELETE FROM events WHERE end_time < date('now')")
     void removePastEvents();
 
     @Query("DELETE FROM events")

--- a/app/src/main/java/de/tum/in/tumcampusapp/component/ui/ticket/EventsController.java
+++ b/app/src/main/java/de/tum/in/tumcampusapp/component/ui/ticket/EventsController.java
@@ -1,15 +1,15 @@
 package de.tum.in.tumcampusapp.component.ui.ticket;
 
-import androidx.lifecycle.LiveData;
-import androidx.lifecycle.MediatorLiveData;
 import android.content.Context;
-import androidx.annotation.NonNull;
 
 import org.jetbrains.annotations.NotNull;
 
 import java.util.ArrayList;
 import java.util.List;
 
+import androidx.annotation.NonNull;
+import androidx.lifecycle.LiveData;
+import androidx.lifecycle.MediatorLiveData;
 import de.tum.in.tumcampusapp.api.app.TUMCabeClient;
 import de.tum.in.tumcampusapp.api.app.exception.NoPrivateKey;
 import de.tum.in.tumcampusapp.api.tumonline.CacheControl;
@@ -144,7 +144,7 @@ public class EventsController implements ProvidesCard {
     }
 
     public LiveData<List<Event>> getEvents() {
-        return eventDao.getAll();
+        return eventDao.getAllFutureEvents();
     }
 
     /**


### PR DESCRIPTION
## Issue

1) This fixes the following issue(s): #1207 
Only showing events that start in the future (tickets should not be affected)

2) Also prevents events from being deleted if they have not passed yet (might still be needed for the ticket), might have been a problem for offline users

