### PR TITLE
Tweak design in kino details view

### DIFF
--- a/app/src/main/java/de/tum/in/tumcampusapp/component/ui/news/KinoDetailsFragment.java
+++ b/app/src/main/java/de/tum/in/tumcampusapp/component/ui/news/KinoDetailsFragment.java
@@ -174,13 +174,13 @@ public class KinoDetailsFragment extends Fragment {
         loadPoster(kino);
 
         TextView dateTextView = rootView.findViewById(R.id.dateTextView);
-        dateTextView.setText(kino.getFormattedDate());
+        dateTextView.setText(kino.getFormattedShortDate());
 
         TextView runtimeTextView = rootView.findViewById(R.id.runtimeTextView);
         runtimeTextView.setText(kino.getRuntime());
 
         TextView ratingTextView = rootView.findViewById(R.id.ratingTextView);
-        ratingTextView.setText(kino.getRating());
+        ratingTextView.setText(kino.getFormattedRating());
 
         int colorPrimary = ContextCompat.getColor(requireContext(), R.color.color_primary);
         setCompoundDrawablesTint(dateTextView, colorPrimary);

--- a/app/src/main/java/de/tum/in/tumcampusapp/component/ui/tufilm/model/Kino.kt
+++ b/app/src/main/java/de/tum/in/tumcampusapp/component/ui/tufilm/model/Kino.kt
@@ -51,7 +51,7 @@ data class Kino(
     val formattedShortDate: String
         get() {
             // e.g. 11/20/2018 8:00 PM (Style SS = short date and short time)
-            val shortDate = DateTimeFormat.shortDate().withLocale(Locale.getDefault()).print(date)
+            val shortDate = DateTimeFormat.forPattern("dd MMM").print(date)
             val shortTime = DateTimeFormat.shortTime().withLocale(Locale.getDefault()).print(date)
             return "$shortDate\n$shortTime"
         }

--- a/app/src/main/java/de/tum/in/tumcampusapp/component/ui/tufilm/model/Kino.kt
+++ b/app/src/main/java/de/tum/in/tumcampusapp/component/ui/tufilm/model/Kino.kt
@@ -7,6 +7,7 @@ import com.google.gson.annotations.SerializedName
 import org.joda.time.DateTime
 import org.joda.time.format.DateTimeFormat
 import java.util.*
+import kotlin.math.roundToInt
 
 /**
  * Kino Constructor
@@ -28,28 +29,31 @@ import java.util.*
  */
 @Entity
 @SuppressWarnings(RoomWarnings.DEFAULT_CONSTRUCTOR)
-data class Kino(@PrimaryKey
-                @SerializedName("kino")
-                var id: String = "",
-                var title: String = "",
-                var year: String = "",
-                var runtime: String = "",
-                var genre: String = "",
-                var director: String = "",
-                var actors: String = "",
-                var rating: String = "",
-                var description: String = "",
-                var cover: String = "",
-                var trailer: String? = "",
-                var date: DateTime = DateTime(),
-                var created: DateTime = DateTime(),
-                var link: String = "") {
+data class Kino(
+        @PrimaryKey
+        @SerializedName("kino")
+        val id: String,
+        val title: String,
+        val year: String,
+        val runtime: String,
+        val genre: String,
+        val director: String,
+        val actors: String,
+        val rating: String,
+        val description: String,
+        val cover: String,
+        val trailer: String?,
+        val date: DateTime,
+        val created: DateTime,
+        val link: String
+) {
 
-    val formattedDate: String
+    val formattedShortDate: String
         get() {
-            // e.g. Nov 20, 2018 8:00 PM (Style MS = medium date and short time)
-            val formatter = DateTimeFormat.forStyle("MS").withLocale(Locale.getDefault())
-            return formatter.print(date)
+            // e.g. 11/20/2018 8:00 PM (Style SS = short date and short time)
+            val shortDate = DateTimeFormat.shortDate().withLocale(Locale.getDefault()).print(date)
+            val shortTime = DateTimeFormat.shortTime().withLocale(Locale.getDefault()).print(date)
+            return "$shortDate\n$shortTime"
         }
 
     val formattedDescription: String
@@ -66,7 +70,10 @@ data class Kino(@PrimaryKey
             return "https://www.youtube.com/results?search_query=Trailer $actualTitle".replace(" ", "+")
         }
 
-    fun isFutureMovie() = date.isAfterNow
+    val formattedRating: String
+        get() {
+            val roundedRating = rating.toDouble().roundToInt()
+            return "$roundedRating / 10"
+        }
 
 }
-

--- a/app/src/main/java/de/tum/in/tumcampusapp/component/ui/tufilm/model/Kino.kt
+++ b/app/src/main/java/de/tum/in/tumcampusapp/component/ui/tufilm/model/Kino.kt
@@ -59,6 +59,8 @@ data class Kino(
     val formattedDescription: String
         get() {
             return description
+                    .replace(".", ". ")   // Add space after full stops
+                    .replace("\\s+", " ") // If this results in multiple spaces, reduce them to one
                     .replace("\n", "")
                     .replace("\r", "\r\n")
                     .removeSuffix("\r\n")

--- a/app/src/main/res/layout/fragment_kinodetails_section.xml
+++ b/app/src/main/res/layout/fragment_kinodetails_section.xml
@@ -12,8 +12,8 @@
         android:orientation="vertical">
 
         <androidx.cardview.widget.CardView
-            android:layout_width="250dp"
-            android:layout_height="375dp"
+            android:layout_width="200dp"
+            android:layout_height="300dp"
             android:layout_gravity="center_horizontal"
             app:cardCornerRadius="@dimen/material_corner_radius"
             app:cardElevation="@dimen/material_default_elevation"

--- a/app/src/test/java/de/tum/in/tumcampusapp/activities/KinoActivityTest.kt
+++ b/app/src/test/java/de/tum/in/tumcampusapp/activities/KinoActivityTest.kt
@@ -17,6 +17,7 @@ import io.reactivex.disposables.CompositeDisposable
 import io.reactivex.plugins.RxJavaPlugins
 import io.reactivex.schedulers.Schedulers
 import org.assertj.core.api.Assertions.assertThat
+import org.joda.time.DateTime
 import org.junit.After
 import org.junit.Before
 import org.junit.Ignore
@@ -63,7 +64,7 @@ class KinoActivityTest {
      */
     @Test
     fun mainComponentDisplayedTest() {
-        dao.insert(Kino())
+        dao.insert(KINO)
         kinoActivity = Robolectric.buildActivity(KinoActivity::class.java).create().start().get()
         waitForUI()
         assertThat(kinoActivity!!.findViewById<View>(R.id.drawer_layout).visibility).isEqualTo(View.VISIBLE)
@@ -88,7 +89,7 @@ class KinoActivityTest {
      */
     @Test
     fun kinoAdapterUsedTest() {
-        dao.insert(Kino())
+        dao.insert(KINO)
         kinoActivity = Robolectric.buildActivity(KinoActivity::class.java).create().start().get()
         waitForUI()
         Thread.sleep(100)
@@ -102,4 +103,24 @@ class KinoActivityTest {
     private fun waitForUI(){
         viewModel.getAllKinos().blockingFirst()
     }
+
+    companion object {
+        private val KINO = Kino(
+                "123",
+                "Deadpool 2",
+                "2018",
+                "137 min",
+                "Comedy",
+                "Someone",
+                "Ryan Reynolds and others",
+                "The best",
+                "I dunno stuff happens",
+                "",
+                null,
+                DateTime.now(),
+                DateTime.now(),
+                ""
+        )
+    }
+
 }


### PR DESCRIPTION
This PR tweaks the design of the kino details view, as shown below.

Main changes: 
- Use shorter date format
- Show “x / 10” for rating
- Improve formatting of the description to prevent full stops without a subsequent space

Old
![screenshot_20181126-193902](https://user-images.githubusercontent.com/11819826/49034826-50b0bc80-f1b3-11e8-9e57-657b5e00c92e.png)

New
![screenshot_20181126-194026](https://user-images.githubusercontent.com/11819826/49034832-55757080-f1b3-11e8-906c-76c1f63217ee.png)
