### PR TITLE
Fix crashes in v3.0

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -635,8 +635,9 @@
             android:name=".service.ScanResultsAvailableReceiver$NeverShowAgainService"
             android:exported="false" />
         <service
-            android:name=".component.tumui.calendar.CalendarController$QueryLocationsService"
-            android:exported="false" />
+            android:name=".service.QueryLocationsService"
+            android:exported="false"
+            android:permission="android.permission.BIND_JOB_SERVICE" />
         <service
             android:name=".service.FcmReceiverService"
             android:stopWithTask="false"

--- a/app/src/main/java/de/tum/in/tumcampusapp/component/other/locations/BuildingToGpsDao.java
+++ b/app/src/main/java/de/tum/in/tumcampusapp/component/other/locations/BuildingToGpsDao.java
@@ -1,17 +1,16 @@
 package de.tum.in.tumcampusapp.component.other.locations;
 
+import java.util.List;
+
 import androidx.room.Dao;
 import androidx.room.Insert;
 import androidx.room.Query;
-
-import java.util.List;
-
 import de.tum.in.tumcampusapp.component.other.locations.model.BuildingToGps;
 
 @Dao
 public interface BuildingToGpsDao {
     @Insert
-    void insert(BuildingToGps buildingToGps);
+    void insert(BuildingToGps... buildingToGps);
 
     @Query("SELECT * FROM buildingtogps")
     List<BuildingToGps> getAll();

--- a/app/src/main/java/de/tum/in/tumcampusapp/component/other/locations/LocationManager.kt
+++ b/app/src/main/java/de/tum/in/tumcampusapp/component/other/locations/LocationManager.kt
@@ -20,6 +20,7 @@ import de.tum.`in`.tumcampusapp.database.TcaDb
 import de.tum.`in`.tumcampusapp.utils.Const
 import de.tum.`in`.tumcampusapp.utils.Utils
 import de.tum.`in`.tumcampusapp.utils.tryOrNull
+import org.jetbrains.anko.doAsync
 import java.io.IOException
 import java.lang.Double.parseDouble
 import java.util.*
@@ -236,7 +237,9 @@ class LocationManager(c: Context) {
      * @return the id of current building
      */
     fun fetchBuildingIDFromCurrentLocation(callback: (String?) -> Unit) {
-        fetchBuildingIDFromLocation(getCurrentOrNextLocation(), callback)
+        doAsync {
+            fetchBuildingIDFromLocation(getCurrentOrNextLocation(), callback)
+        }
     }
 
     /**

--- a/app/src/main/java/de/tum/in/tumcampusapp/component/other/locations/LocationManager.kt
+++ b/app/src/main/java/de/tum/in/tumcampusapp/component/other/locations/LocationManager.kt
@@ -213,21 +213,20 @@ class LocationManager(c: Context) {
 
     /**
      * This method tries to get the list of BuildingToGps by querying database or requesting the server.
-     * If both two ways fail, it returns Optional.absent().
+     * If both two ways fail, it returns an empty list.
      * we have to fetch buildings to gps mapping first.
      * @return The list of BuildingToGps
      */
     private fun fetchBuildingsToGps(): List<BuildingToGps> {
         val results = buildingToGpsDao.all.orEmpty()
-        if (results.isEmpty()) {
-            val newResults = tryOrNull { TUMCabeClient.getInstance(mContext).building2Gps }
-            newResults?.let {
-                buildingToGpsDao.insert(*it.toTypedArray())
-                return newResults
-            }
+        if (results.isNotEmpty()) {
+            return results
         }
 
-        return results
+        val newResults = tryOrNull { TUMCabeClient.getInstance(mContext).building2Gps }
+        return newResults.orEmpty().also {
+            buildingToGpsDao.insert(*it.toTypedArray())
+        }
     }
 
     /**

--- a/app/src/main/java/de/tum/in/tumcampusapp/component/other/locations/RoomLocationsDao.java
+++ b/app/src/main/java/de/tum/in/tumcampusapp/component/other/locations/RoomLocationsDao.java
@@ -16,7 +16,7 @@ public interface RoomLocationsDao {
     RoomLocations getNextLectureCoordinates();
 
     @Insert
-    void insert(RoomLocations roomLocations);
+    void insert(RoomLocations... roomLocations);
 
     @Query("DELETE FROM room_locations")
     void flush();

--- a/app/src/main/java/de/tum/in/tumcampusapp/component/tumui/calendar/CalendarActivity.java
+++ b/app/src/main/java/de/tum/in/tumcampusapp/component/tumui/calendar/CalendarActivity.java
@@ -48,6 +48,7 @@ import de.tum.in.tumcampusapp.component.tumui.calendar.model.Event;
 import de.tum.in.tumcampusapp.component.tumui.calendar.model.EventsResponse;
 import de.tum.in.tumcampusapp.component.ui.transportation.TransportController;
 import de.tum.in.tumcampusapp.database.TcaDb;
+import de.tum.in.tumcampusapp.service.QueryLocationsService;
 import de.tum.in.tumcampusapp.utils.Const;
 import de.tum.in.tumcampusapp.utils.DateTimeUtils;
 import de.tum.in.tumcampusapp.utils.Utils;
@@ -181,14 +182,14 @@ public class CalendarActivity extends ActivityForAccessingTumOnline<EventsRespon
                         .fromAction(() -> calendarController.importCalendar(events))
                         .subscribeOn(Schedulers.io())
                         .observeOn(AndroidSchedulers.mainThread())
-                        .subscribe(() -> {
-                            // Update the action bar to display the enabled menu options
-                            invalidateOptionsMenu();
-                            Intent intent = new Intent(
-                                    this, CalendarController.QueryLocationsService.class);
-                            startService(intent);
-                        })
+                        .subscribe(this::onCalendarImportedIntoDatabase)
         );
+    }
+
+    private void onCalendarImportedIntoDatabase() {
+        // Update the action bar to display the enabled menu options
+        invalidateOptionsMenu();
+        QueryLocationsService.enqueueWork(this);
     }
 
     private void scheduleNotifications(@NonNull List<Event> events) {

--- a/app/src/main/java/de/tum/in/tumcampusapp/component/tumui/lectures/model/RoomLocations.kt
+++ b/app/src/main/java/de/tum/in/tumcampusapp/component/tumui/lectures/model/RoomLocations.kt
@@ -10,10 +10,13 @@ import de.tum.`in`.tumcampusapp.component.other.locations.model.Geo
  */
 @Entity(tableName = "room_locations")
 @SuppressWarnings(RoomWarnings.DEFAULT_CONSTRUCTOR)
-data class RoomLocations(@PrimaryKey
-                         var title: String = "",
-                         var latitude: String = "",
-                         var longitude: String = "") {
+data class RoomLocations(
+        @PrimaryKey
+        var title: String = "",
+        var latitude: String = "",
+        var longitude: String = ""
+) {
+
     constructor(title: String, geo: Geo) : this(title, geo.latitude, geo.longitude)
 
     /**
@@ -22,4 +25,5 @@ data class RoomLocations(@PrimaryKey
     fun toGeo(): Geo {
         return Geo(latitude, longitude);
     }
+
 }

--- a/app/src/main/java/de/tum/in/tumcampusapp/component/ui/barrierfree/BarrierFreeFacilitiesActivity.kt
+++ b/app/src/main/java/de/tum/in/tumcampusapp/component/ui/barrierfree/BarrierFreeFacilitiesActivity.kt
@@ -34,18 +34,22 @@ class BarrierFreeFacilitiesActivity : ActivityForAccessingTumCabe<List<RoomFinde
     }
 
     override fun onItemSelected(parent: AdapterView<*>, view: View, position: Int, id: Long) {
-        val apiCall = when (position) {
-            0 -> getApiCallForCurrentLocation()
-            1 -> apiClient.listOfToilets
-            else -> apiClient.listOfElevators
+        when (position) {
+            0 -> fetchApiCallForCurrentLocation()
+            1 -> executeApiCall(apiClient.listOfElevators)
+            else -> executeApiCall(apiClient.listOfElevators)
         }
-
-        apiCall?.let { fetch(it) } ?: showError(R.string.error_something_wrong)
     }
 
-    private fun getApiCallForCurrentLocation(): Call<List<RoomFinderRoom>>? {
-        val buildingId = locationManager.getBuildingIDFromCurrentLocation() ?: return null
-        return apiClient.getListOfNearbyFacilities(buildingId)
+    private fun fetchApiCallForCurrentLocation() {
+        locationManager.fetchBuildingIDFromCurrentLocation {
+            val apiCall = apiClient.getListOfNearbyFacilities(it)
+            executeApiCall(apiCall)
+        }
+    }
+
+    private fun executeApiCall(apiCall: Call<List<RoomFinderRoom>>?) {
+        apiCall?.let { fetch(it) } ?: showError(R.string.error_something_wrong)
     }
 
     override fun onDownloadSuccessful(response: List<RoomFinderRoom>) {

--- a/app/src/main/java/de/tum/in/tumcampusapp/component/ui/cafeteria/widget/MensaRemoteViewFactory.java
+++ b/app/src/main/java/de/tum/in/tumcampusapp/component/ui/cafeteria/widget/MensaRemoteViewFactory.java
@@ -37,7 +37,7 @@ public class MensaRemoteViewFactory implements RemoteViewsService.RemoteViewsFac
 
     @Override
     public void onDestroy() {
-        // Noop 
+        // Noop
     }
 
     @Override
@@ -47,8 +47,12 @@ public class MensaRemoteViewFactory implements RemoteViewsService.RemoteViewsFac
 
     @Override
     public RemoteViews getViewAt(int position) {
-        CafeteriaMenu currentItem = mMenus.get(position);
+        if (position >= mMenus.size()) {
+            // No idea why this happens, but getViewAt is occasionally called with position == size
+            return getLoadingView();
+        }
 
+        CafeteriaMenu currentItem = mMenus.get(position);
         RemoteViews rv = new RemoteViews(mApplicationContext.getPackageName(), R.layout.mensa_widget_item);
 
         String menuContent = COMPILE.matcher(currentItem.getName())
@@ -68,7 +72,7 @@ public class MensaRemoteViewFactory implements RemoteViewsService.RemoteViewsFac
 
     @Override
     public RemoteViews getLoadingView() {
-        return null;
+        return new RemoteViews(mApplicationContext.getPackageName(), R.layout.mensa_widget_loading_item);
     }
 
     @Override

--- a/app/src/main/java/de/tum/in/tumcampusapp/component/ui/studyroom/StudyRoomsActivity.kt
+++ b/app/src/main/java/de/tum/in/tumcampusapp/component/ui/studyroom/StudyRoomsActivity.kt
@@ -5,7 +5,6 @@ import android.R.layout.simple_spinner_dropdown_item
 import android.app.SearchManager
 import android.content.Intent
 import android.os.Bundle
-import androidx.viewpager.widget.ViewPager
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -13,6 +12,7 @@ import android.widget.AdapterView
 import android.widget.ArrayAdapter
 import android.widget.Spinner
 import android.widget.TextView
+import androidx.viewpager.widget.ViewPager
 import de.tum.`in`.tumcampusapp.R
 import de.tum.`in`.tumcampusapp.component.other.generic.activity.ActivityForAccessingTumCabe
 import de.tum.`in`.tumcampusapp.component.tumui.roomfinder.RoomFinderActivity
@@ -62,10 +62,7 @@ class StudyRoomsActivity : ActivityForAccessingTumCabe<List<StudyRoomGroup>>(
 
     override fun onRefresh() = loadStudyRooms()
 
-    /**
-     * A new study room group has been selected -> Switch.
-     */
-    override fun onItemSelected(parent: AdapterView<*>, view: View, pos: Int, id: Long) {
+    override fun onItemSelected(parent: AdapterView<*>?, view: View?, pos: Int, id: Long) {
         groupId = groups[pos].id
         changeViewPagerAdapter(groupId)
     }

--- a/app/src/main/java/de/tum/in/tumcampusapp/database/TcaDb.java
+++ b/app/src/main/java/de/tum/in/tumcampusapp/database/TcaDb.java
@@ -20,7 +20,6 @@ import de.tum.in.tumcampusapp.component.other.locations.RoomLocationsDao;
 import de.tum.in.tumcampusapp.component.other.locations.model.BuildingToGps;
 import de.tum.in.tumcampusapp.component.other.wifimeasurement.WifiMeasurementDao;
 import de.tum.in.tumcampusapp.component.other.wifimeasurement.model.WifiMeasurement;
-import de.tum.in.tumcampusapp.component.tumui.calendar.CalendarController;
 import de.tum.in.tumcampusapp.component.tumui.calendar.CalendarDao;
 import de.tum.in.tumcampusapp.component.tumui.calendar.WidgetsTimetableBlacklistDao;
 import de.tum.in.tumcampusapp.component.tumui.calendar.model.CalendarItem;
@@ -62,6 +61,7 @@ import de.tum.in.tumcampusapp.database.migrations.Migration1to2;
 import de.tum.in.tumcampusapp.database.migrations.Migration2to3;
 import de.tum.in.tumcampusapp.service.BackgroundService;
 import de.tum.in.tumcampusapp.service.DownloadService;
+import de.tum.in.tumcampusapp.service.QueryLocationsService;
 import de.tum.in.tumcampusapp.service.SendMessageService;
 import de.tum.in.tumcampusapp.service.SilenceService;
 import de.tum.in.tumcampusapp.utils.CacheManager;
@@ -176,7 +176,7 @@ public abstract class TcaDb extends RoomDatabase {
     public static void resetDb(Context c) {
         // Stop all services, since they might have instantiated Managers and cause SQLExceptions
         Class<?>[] services = new Class<?>[]{
-                CalendarController.QueryLocationsService.class,
+                QueryLocationsService.class,
                 SendMessageService.class,
                 SilenceService.class,
                 DownloadService.class,

--- a/app/src/main/java/de/tum/in/tumcampusapp/service/QueryLocationsService.kt
+++ b/app/src/main/java/de/tum/in/tumcampusapp/service/QueryLocationsService.kt
@@ -1,0 +1,76 @@
+package de.tum.`in`.tumcampusapp.service
+
+import android.Manifest.permission.WRITE_CALENDAR
+import android.content.Context
+import android.content.Intent
+import android.content.pm.PackageManager.PERMISSION_GRANTED
+import android.database.sqlite.SQLiteException
+import androidx.core.app.JobIntentService
+import androidx.core.content.ContextCompat
+import de.tum.`in`.tumcampusapp.component.other.locations.LocationManager
+import de.tum.`in`.tumcampusapp.component.tumui.calendar.CalendarController
+import de.tum.`in`.tumcampusapp.component.tumui.lectures.model.RoomLocations
+import de.tum.`in`.tumcampusapp.database.TcaDb
+import de.tum.`in`.tumcampusapp.utils.Const
+import de.tum.`in`.tumcampusapp.utils.Utils
+import de.tum.`in`.tumcampusapp.utils.sync.SyncManager
+import org.jetbrains.anko.doAsync
+
+class QueryLocationsService : JobIntentService() {
+
+    override fun onHandleWork(intent: Intent) {
+        doAsync {
+            loadGeo()
+        }
+    }
+
+    private fun loadGeo() {
+        val locationManager = LocationManager(this)
+        val calendarDao = TcaDb.getInstance(this).calendarDao()
+        val roomLocationsDao = TcaDb.getInstance(this).roomLocationsDao()
+
+        val calendarItems = calendarDao.lecturesWithoutCoordinates
+        for (calendarItem in calendarItems) {
+            val location = calendarItem.location
+            if (location.isEmpty()) {
+                continue
+            }
+
+            val geo = locationManager.roomLocationStringToGeo(location)
+            geo?.let {
+                Utils.logv("inserted " + location + ' '.toString() + it)
+                roomLocationsDao.insert(RoomLocations(location, it))
+            }
+        }
+
+        // Do sync of google calendar if necessary
+        val shouldSyncCalendar = Utils.getSettingBool(this, Const.SYNC_CALENDAR, false)
+                && ContextCompat.checkSelfPermission(this, WRITE_CALENDAR) == PERMISSION_GRANTED
+        val syncManager = SyncManager(this)
+        val needsSync = syncManager.needSync(Const.SYNC_CALENDAR, TIME_TO_SYNC_CALENDAR)
+
+        if (shouldSyncCalendar.not() || needsSync.not()) {
+            return
+        }
+
+        try {
+            CalendarController.syncCalendar(this)
+            syncManager.replaceIntoDb(Const.SYNC_CALENDAR)
+        } catch (e: SQLiteException) {
+            Utils.log(e)
+        }
+    }
+
+    companion object {
+
+        private const val TIME_TO_SYNC_CALENDAR = 604800 // 1 week
+
+        @JvmStatic fun enqueueWork(context: Context) {
+            Utils.log("Query locations work enqueued")
+            JobIntentService.enqueueWork(context, QueryLocationsService::class.java,
+                    Const.QUERY_LOCATIONS_SERVICE_JOB_ID, Intent())
+        }
+
+    }
+
+}

--- a/app/src/main/java/de/tum/in/tumcampusapp/utils/CacheManager.kt
+++ b/app/src/main/java/de/tum/in/tumcampusapp/utils/CacheManager.kt
@@ -7,6 +7,7 @@ import de.tum.`in`.tumcampusapp.component.tumui.calendar.CalendarController
 import de.tum.`in`.tumcampusapp.component.tumui.calendar.model.EventsResponse
 import de.tum.`in`.tumcampusapp.component.tumui.lectures.model.LecturesResponse
 import de.tum.`in`.tumcampusapp.component.ui.chat.ChatRoomController
+import de.tum.`in`.tumcampusapp.service.QueryLocationsService
 import okhttp3.Cache
 import org.jetbrains.anko.doAsync
 import retrofit2.Call
@@ -45,7 +46,7 @@ class CacheManager(private val context: Context) {
 
     private fun loadRoomLocations() {
         doAsync {
-            CalendarController.QueryLocationsService.loadGeo(context)
+            QueryLocationsService.enqueueWork(context)
         }
     }
 

--- a/app/src/main/java/de/tum/in/tumcampusapp/utils/Const.kt
+++ b/app/src/main/java/de/tum/in/tumcampusapp/utils/Const.kt
@@ -91,6 +91,7 @@ object Const {
     const val SEND_WIFI_SERVICE_JOB_ID = 1003
     const val DOWNLOAD_SERVICE_JOB_ID = 1004
     const val FILL_CACHE_SERVICE_JOB_ID = 1005
+    const val QUERY_LOCATIONS_SERVICE_JOB_ID = 1006
 
     const val FEEDBACK_MESSAGE = "feedback_message"
     const val FEEDBACK_PIC_PATHS = "feedback_paths"

--- a/app/src/main/res/layout/mensa_widget_loading_item.xml
+++ b/app/src/main/res/layout/mensa_widget_loading_item.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:padding="@dimen/material_small_padding">
+
+    <TextView
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:gravity="center_vertical"
+        android:text="@string/loading"
+        android:textColor="#ff656865"
+        android:textSize="16sp" />
+
+</FrameLayout>


### PR DESCRIPTION
This pull request fixes the crashes that affect the most users in version 3.0:
1. `NetworkOnMainThreadException` in `BarrierFreeFacilitiesActivity`(fixed by moving the network call to a background thread)
2. Situations where view was null in `StudyRoomsActivity` (fixed by making it nullable; it’s not used anyway)
3. Crash when `CalendarController.QueryLocationsService` could not be started (convert `IntentService` into `JobIntentService`, which don’t experience the same crashes)