### PR TITLE
Refactor CafeteriaActivity and view model

### DIFF
--- a/.idea/inspectionProfiles/Project_Default.xml
+++ b/.idea/inspectionProfiles/Project_Default.xml
@@ -98,7 +98,7 @@
       <option name="useParameterizedTypeForCollectionMethods" value="true" />
       <option name="doNotWeakenToJavaLangObject" value="true" />
       <option name="onlyWeakentoInterface" value="true" />
-      <stopClasses>java.util.List,org.joda.time.LocalDate,de.tum.in.tumcampusapp.component.ui.barrierfree.BarrierfreeContactAdapter</stopClasses>
+      <stopClasses>java.util.List,org.joda.time.LocalDate,de.tum.in.tumcampusapp.component.ui.barrierfree.BarrierfreeContactAdapter,de.tum.in.tumcampusapp.component.ui.cafeteria.details.CafeteriaViewModel.Factory</stopClasses>
     </inspection_tool>
     <inspection_tool class="UnnecessaryConstantArrayCreationExpression" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="UnnecessaryConstructor" enabled="true" level="WARNING" enabled_by_default="true" />

--- a/app/src/main/java/de/tum/in/tumcampusapp/component/other/generic/activity/ProgressActivity.kt
+++ b/app/src/main/java/de/tum/in/tumcampusapp/component/other/generic/activity/ProgressActivity.kt
@@ -245,6 +245,12 @@ abstract class ProgressActivity<T>(
         }
     }
 
+    protected fun showContentLayout() {
+        runOnUiThread {
+            errorLayout.visibility = View.GONE
+        }
+    }
+
     protected fun showErrorLayout() {
         runOnUiThread {
             errorLayout.visibility = View.VISIBLE

--- a/app/src/main/java/de/tum/in/tumcampusapp/component/ui/cafeteria/CafeteriaDao.java
+++ b/app/src/main/java/de/tum/in/tumcampusapp/component/ui/cafeteria/CafeteriaDao.java
@@ -1,13 +1,12 @@
 package de.tum.in.tumcampusapp.component.ui.cafeteria;
 
+import java.util.List;
+
+import androidx.annotation.Nullable;
 import androidx.room.Dao;
 import androidx.room.Insert;
 import androidx.room.OnConflictStrategy;
 import androidx.room.Query;
-import androidx.annotation.Nullable;
-
-import java.util.List;
-
 import de.tum.in.tumcampusapp.component.ui.cafeteria.model.Cafeteria;
 import io.reactivex.Flowable;
 
@@ -24,7 +23,7 @@ public interface CafeteriaDao {
     void removeCache();
 
     @Insert(onConflict = OnConflictStrategy.REPLACE)
-    void insert(Cafeteria cafeteria);
+    void insert(Cafeteria... cafeteria);
 
     @Query("SELECT name FROM cafeteria WHERE id = :id")
     String getMensaNameFromId(int id);

--- a/app/src/main/java/de/tum/in/tumcampusapp/component/ui/cafeteria/CafeteriaNotificationProvider.kt
+++ b/app/src/main/java/de/tum/in/tumcampusapp/component/ui/cafeteria/CafeteriaNotificationProvider.kt
@@ -12,6 +12,7 @@ import de.tum.`in`.tumcampusapp.component.other.locations.LocationManager
 import de.tum.`in`.tumcampusapp.component.ui.cafeteria.controller.CafeteriaMenuManager
 import de.tum.`in`.tumcampusapp.component.ui.cafeteria.model.MenuType
 import de.tum.`in`.tumcampusapp.component.ui.cafeteria.repository.CafeteriaLocalRepository
+import de.tum.`in`.tumcampusapp.database.TcaDb
 import de.tum.`in`.tumcampusapp.utils.Const
 import de.tum.`in`.tumcampusapp.utils.DateTimeUtils
 import org.joda.time.DateTime
@@ -36,7 +37,8 @@ class CafeteriaNotificationProvider(context: Context) : NotificationProvider(con
             return null
         }
 
-        val cafeteria = CafeteriaLocalRepository.getCafeteriaWithMenus(cafeteriaId)
+        val localRepo = CafeteriaLocalRepository(TcaDb.getInstance(context))
+        val cafeteria = localRepo.getCafeteriaWithMenus(cafeteriaId)
         val menus = cafeteria.menus.filter { it.menuType != MenuType.SIDE_DISH }
         val intent = cafeteria.getIntent(context)
 

--- a/app/src/main/java/de/tum/in/tumcampusapp/component/ui/cafeteria/activity/CafeteriaActivity.java
+++ b/app/src/main/java/de/tum/in/tumcampusapp/component/ui/cafeteria/activity/CafeteriaActivity.java
@@ -3,9 +3,6 @@ package de.tum.in.tumcampusapp.component.ui.cafeteria.activity;
 import android.content.Intent;
 import android.location.Location;
 import android.os.Bundle;
-import androidx.annotation.NonNull;
-import androidx.viewpager.widget.ViewPager;
-import androidx.appcompat.app.AlertDialog;
 import android.text.SpannableString;
 import android.view.LayoutInflater;
 import android.view.Menu;
@@ -17,10 +14,15 @@ import android.widget.ArrayAdapter;
 import android.widget.Spinner;
 import android.widget.TextView;
 
+import org.joda.time.DateTime;
+
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.List;
 
+import androidx.annotation.NonNull;
+import androidx.appcompat.app.AlertDialog;
+import androidx.lifecycle.ViewModelProviders;
+import androidx.viewpager.widget.ViewPager;
 import de.tum.in.tumcampusapp.R;
 import de.tum.in.tumcampusapp.api.app.TUMCabeClient;
 import de.tum.in.tumcampusapp.component.other.generic.activity.ActivityForDownloadingExternal;
@@ -34,24 +36,27 @@ import de.tum.in.tumcampusapp.component.ui.cafeteria.repository.CafeteriaLocalRe
 import de.tum.in.tumcampusapp.component.ui.cafeteria.repository.CafeteriaRemoteRepository;
 import de.tum.in.tumcampusapp.database.TcaDb;
 import de.tum.in.tumcampusapp.utils.Const;
-import de.tum.in.tumcampusapp.utils.NetUtils;
 import de.tum.in.tumcampusapp.utils.Utils;
-import io.reactivex.Flowable;
-import io.reactivex.disposables.CompositeDisposable;
 
 /**
  * Lists all dishes at selected cafeteria
  * <p>
  * OPTIONAL: Const.CAFETERIA_ID set in incoming bundle (cafeteria to show)
  */
-public class CafeteriaActivity extends ActivityForDownloadingExternal implements AdapterView.OnItemSelectedListener {
+public class CafeteriaActivity extends ActivityForDownloadingExternal
+        implements AdapterView.OnItemSelectedListener {
 
-    private ViewPager mViewPager;
-    private int mCafeteriaId = -1;
-    private CafeteriaViewModel cafeteriaViewModel;
+    private static final int NONE_SELECTED = -1;
+
     private List<Cafeteria> mCafeterias = new ArrayList<>();
 
-    private final CompositeDisposable mDisposable = new CompositeDisposable();
+    private CafeteriaViewModel cafeteriaViewModel;
+
+    private ArrayAdapter<Cafeteria> adapter;
+    private CafeteriaDetailsSectionsPagerAdapter sectionsPagerAdapter;
+
+    private ViewPager viewPager;
+    private Spinner spinner;
 
     public CafeteriaActivity() {
         super(Const.CAFETERIAS, R.layout.activity_cafeteria);
@@ -60,142 +65,116 @@ public class CafeteriaActivity extends ActivityForDownloadingExternal implements
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-        // Get id from intent if specified
-        final Intent intent = getIntent();
-        if (intent != null && intent.getExtras() != null
-                && intent.getExtras().containsKey(Const.CAFETERIA_ID)) {
-            mCafeteriaId = intent.getExtras()
-                                 .getInt(Const.CAFETERIA_ID);
-        } else {
-            // If we're not provided with a cafeteria ID, we choose the best matching cafeteria.
-            int cafeteriaId = new CafeteriaManager(this).getBestMatchMensaId();
-            if (cafeteriaId == -1) {
-                mCafeteriaId = cafeteriaId;
+
+        viewPager = findViewById(R.id.pager);
+        viewPager.setOffscreenPageLimit(50);
+
+        adapter = createArrayAdapter();
+
+        spinner = findViewById(R.id.spinnerToolbar);
+        spinner.setAdapter(adapter);
+        spinner.setOnItemSelectedListener(this);
+
+        initCafeteriaSpinner();
+        sectionsPagerAdapter = new CafeteriaDetailsSectionsPagerAdapter(getSupportFragmentManager());
+
+        TUMCabeClient client = TUMCabeClient.getInstance(this);
+        CafeteriaRemoteRepository remoteRepository = new CafeteriaRemoteRepository(client);
+
+        TcaDb db = TcaDb.getInstance(this);
+        CafeteriaLocalRepository localRepository = new CafeteriaLocalRepository(db);
+
+        CafeteriaViewModel.Factory factory =
+                new CafeteriaViewModel.Factory(localRepository, remoteRepository);
+        cafeteriaViewModel = ViewModelProviders.of(this, factory).get(CafeteriaViewModel.class);
+
+        cafeteriaViewModel.getCafeterias().observe(this, this::updateCafeteria);
+        cafeteriaViewModel.getSelectedCafeteria().observe(this, this::onNewCafeteriaSelected);
+        cafeteriaViewModel.getMenuDates().observe(this, this::updateSectionsPagerAdapter);
+
+        cafeteriaViewModel.getError().observe(this, value -> {
+            if (value) {
+                showError(R.string.error_something_wrong);
+            } else {
+                showContentLayout();
             }
-        }
-
-        mViewPager = findViewById(R.id.pager);
-
-        /*
-         *set pagelimit to avoid losing toggle button state.
-         *by default it's 1.
-         */
-        mViewPager.setOffscreenPageLimit(50);
-
-        CafeteriaRemoteRepository remoteRepository = CafeteriaRemoteRepository.INSTANCE;
-        remoteRepository.setTumCabeClient(TUMCabeClient.getInstance(this));
-
-        CafeteriaLocalRepository localRepository = CafeteriaLocalRepository.INSTANCE;
-        localRepository.setDb(TcaDb.getInstance(this));
-
-        cafeteriaViewModel = new CafeteriaViewModel(localRepository, remoteRepository, mDisposable);
+        });
     }
 
-    @Override
-    public boolean onCreateOptionsMenu(Menu menu) {
-        // Add info icon to show ingredients
-        getMenuInflater().inflate(R.menu.menu_section_fragment_cafeteria_details, menu);
-        return true;
+    private void updateCafeteria(List<Cafeteria> cafeterias) {
+        mCafeterias = cafeterias;
+        adapter.clear();
+        adapter.addAll(cafeterias);
+        adapter.notifyDataSetChanged();
     }
 
-    @Override
-    public boolean onOptionsItemSelected(MenuItem item) {
-        if (item.getItemId() == R.id.action_ingredients) {
-            // Build a alert dialog containing the mapping of ingredients to the numbers
-            String ingredients = getString(R.string.cafeteria_ingredients);
-            SpannableString title = CafeteriaMenuInflater.menuToSpan(this, ingredients);
-
-            AlertDialog dialog = new AlertDialog.Builder(this)
-                    .setTitle(R.string.action_ingredients)
-                    .setMessage(title)
-                    .setPositiveButton(R.string.ok, null)
-                    .create();
-
-            if (dialog.getWindow() != null) {
-                dialog.getWindow().setBackgroundDrawableResource(R.drawable.rounded_corners_background);
-            }
-
-            dialog.show();
-            return true;
-        }
-        if (item.getItemId() == R.id.action_settings) {
-            startActivity(new Intent(this, CafeteriaNotificationSettingsActivity.class));
-            return true;
-        }
-        return super.onOptionsItemSelected(item);
-    }
-
-    /**
-     * Setup action bar navigation (to switch between cafeterias)
-     */
-    @Override
-    protected void onStart() {
-        super.onStart();
-
-        // Adapter for drop-down navigation
-        ArrayAdapter<Cafeteria> adapterCafeterias = new ArrayAdapter<Cafeteria>(
+    private ArrayAdapter<Cafeteria> createArrayAdapter() {
+        return new ArrayAdapter<Cafeteria>(
                 this, R.layout.simple_spinner_item_actionbar, android.R.id.text1, mCafeterias) {
             final LayoutInflater inflater = LayoutInflater.from(getContext());
 
             @Override
             public View getDropDownView(int position, View convertView, @NonNull ViewGroup parent) {
-                View v = inflater.inflate(R.layout.simple_spinner_dropdown_item_actionbar_two_line, parent, false);
-                Cafeteria c = getItem(position);
+                View v = inflater.inflate(
+                        R.layout.simple_spinner_dropdown_item_actionbar_two_line, parent, false);
+                Cafeteria cafeteria = getItem(position);
 
-                TextView name = v.findViewById(android.R.id.text1); // Set name
-                TextView address = v.findViewById(android.R.id.text2); // Set address
-                TextView dist = v.findViewById(R.id.distance); // Set distance
+                TextView name = v.findViewById(android.R.id.text1);
+                TextView address = v.findViewById(android.R.id.text2);
+                TextView distance = v.findViewById(R.id.distance);
 
-                if (c != null) {
-                    name.setText(c.getName());
-                    address.setText(c.getAddress());
-                    dist.setText(Utils.formatDistance(c.getDistance()));
+                if (cafeteria != null) {
+                    name.setText(cafeteria.getName());
+                    address.setText(cafeteria.getAddress());
+                    distance.setText(Utils.formatDistance(cafeteria.getDistance()));
                 }
 
                 return v;
             }
         };
-
-        Spinner spinner = findViewById(R.id.spinnerToolbar);
-        spinner.setAdapter(adapterCafeterias);
-        spinner.setOnItemSelectedListener(this);
-
-        Location currLocation = new LocationManager(this).getCurrentOrNextLocation();
-        Flowable<List<Cafeteria>> cafeterias = cafeteriaViewModel.getAllCafeterias(currLocation);
-        mDisposable.add(
-                cafeterias.subscribe(
-                        it -> {
-                            validateList(it);
-                            mCafeterias.clear();
-                            mCafeterias.addAll(it);
-                            adapterCafeterias.notifyDataSetChanged();
-                            setCurrentSelectedCafeteria(spinner);
-                        }, throwable -> Utils.logwithTag("CafeteriaActivity", throwable.getMessage())
-                ));
     }
 
-    private void validateList(Collection<Cafeteria> cafeterias) {
-        if (cafeterias.isEmpty()) {
-            if (NetUtils.isConnected(this)) {
-                showErrorLayout();
-            } else {
-                showNoInternetLayout();
-            }
+    @Override
+    protected void onStart() {
+        super.onStart();
+        Location location = new LocationManager(this).getCurrentOrNextLocation();
+        cafeteriaViewModel.fetchCafeterias(location);
+    }
+
+    private void initCafeteriaSpinner() {
+        final Intent intent = getIntent();
+        int cafeteriaId;
+
+        if (intent != null && intent.hasExtra(Const.MENSA_FOR_FAVORITEDISH)) {
+            cafeteriaId = intent.getIntExtra(Const.MENSA_FOR_FAVORITEDISH, NONE_SELECTED);
+            intent.removeExtra(Const.MENSA_FOR_FAVORITEDISH);
+        } else if (intent.getExtras() != null && intent.hasExtra(Const.CAFETERIA_ID)) {
+            cafeteriaId = intent.getIntExtra(Const.CAFETERIA_ID, 0);
+        } else {
+            // If we're not provided with a cafeteria ID, we choose the best matching cafeteria.
+            cafeteriaId = new CafeteriaManager(this).getBestMatchMensaId();
         }
+
+        updateCafeteriaSpinner(cafeteriaId);
     }
 
-    private void setCurrentSelectedCafeteria(Spinner spinner) {
-        int selIndex = -1;
+    private void onNewCafeteriaSelected(Cafeteria cafeteria) {
+        sectionsPagerAdapter.setCafeteriaId(cafeteria.getId());
+        cafeteriaViewModel.fetchMenuDates();
+    }
+
+    private void updateCafeteriaSpinner(int cafeteriaId) {
+        int selectedIndex = NONE_SELECTED;
         for (int i = 0; i < mCafeterias.size(); i++) {
-            Cafeteria c = mCafeterias.get(i);
-            if (mCafeteriaId == -1 || mCafeteriaId == c.getId()) {
-                mCafeteriaId = c.getId();
-                selIndex = i;
+            Cafeteria cafeteria = mCafeterias.get(i);
+            if (cafeteriaId == NONE_SELECTED || cafeteriaId == cafeteria.getId()) {
+                selectedIndex = i;
                 break;
             }
         }
-        if (selIndex > -1) {
-            spinner.setSelection(selIndex);
+
+        if (selectedIndex != NONE_SELECTED) {
+            spinner.setSelection(selectedIndex);
         }
     }
 
@@ -208,43 +187,57 @@ public class CafeteriaActivity extends ActivityForDownloadingExternal implements
      */
     @Override
     public void onItemSelected(AdapterView<?> parent, View view, int pos, long id) {
-        Intent intent = getIntent();
-        //check if Activity triggered from favoriteDish Notification
-        if (intent != null && intent.getExtras() != null && intent.getExtras()
-                                                                  .containsKey(Const.MENSA_FOR_FAVORITEDISH)) {
-            for (int i = 0; i < parent.getCount(); i++) {
-                //get mensaId from extra to redirect the user to it.
-                if (intent.getExtras()
-                          .getInt(Const.MENSA_FOR_FAVORITEDISH) == mCafeterias.get(i)
-                                                                              .getId()) {
-                    mCafeteriaId = mCafeterias.get(i)
-                                              .getId();
-                    parent.setSelection(i);
-                    intent.removeExtra(Const.MENSA_FOR_FAVORITEDISH);
-                    break;
-                }
-            }
-        } else {
-            mCafeteriaId = mCafeterias.get(pos)
-                                      .getId();
-        }
+        Cafeteria selected = mCafeterias.get(pos);
+        cafeteriaViewModel.updateSelectedCafeteria(selected);
+    }
 
-        CafeteriaDetailsSectionsPagerAdapter mSectionsPagerAdapter
-                = new CafeteriaDetailsSectionsPagerAdapter(getSupportFragmentManager());
-        // Create the adapter that will return a fragment for each of the primary sections of the app.
-        mViewPager.setAdapter(null); //unset the adapter for updating
-        mSectionsPagerAdapter.setCafeteriaId(this, mCafeteriaId);
-        mViewPager.setAdapter(mSectionsPagerAdapter);
+    private void updateSectionsPagerAdapter(List<DateTime> menuDates) {
+        viewPager.setAdapter(null);
+        sectionsPagerAdapter.update(menuDates);
+        viewPager.setAdapter(sectionsPagerAdapter);
     }
 
     @Override
     public void onNothingSelected(AdapterView<?> parent) {
-        //Don't change anything
+        // Don't change anything
     }
 
     @Override
-    protected void onDestroy() {
-        mDisposable.clear();
-        super.onDestroy();
+    public boolean onCreateOptionsMenu(Menu menu) {
+        getMenuInflater().inflate(R.menu.menu_section_fragment_cafeteria_details, menu);
+        return true;
     }
+
+    @Override
+    public boolean onOptionsItemSelected(@NonNull MenuItem item) {
+        switch (item.getItemId()) {
+            case R.id.action_ingredients:
+                showIngredientsInfo();
+                break;
+            case R.id.action_settings:
+                startActivity(new Intent(this, CafeteriaNotificationSettingsActivity.class));
+                break;
+        }
+
+        return super.onOptionsItemSelected(item);
+    }
+
+    private void showIngredientsInfo() {
+        // Build a alert dialog containing the mapping of ingredients to the numbers
+        String ingredients = getString(R.string.cafeteria_ingredients);
+        SpannableString message = CafeteriaMenuInflater.menuToSpan(this, ingredients);
+
+        AlertDialog dialog = new AlertDialog.Builder(this)
+                .setTitle(R.string.action_ingredients)
+                .setMessage(message)
+                .setPositiveButton(R.string.ok, null)
+                .create();
+
+        if (dialog.getWindow() != null) {
+            dialog.getWindow().setBackgroundDrawableResource(R.drawable.rounded_corners_background);
+        }
+
+        dialog.show();
+    }
+
 }

--- a/app/src/main/java/de/tum/in/tumcampusapp/component/ui/cafeteria/activity/CafeteriaActivity.java
+++ b/app/src/main/java/de/tum/in/tumcampusapp/component/ui/cafeteria/activity/CafeteriaActivity.java
@@ -86,8 +86,8 @@ public class CafeteriaActivity extends ActivityForDownloadingExternal
         cafeteriaViewModel.getSelectedCafeteria().observe(this, this::onNewCafeteriaSelected);
         cafeteriaViewModel.getMenuDates().observe(this, this::updateSectionsPagerAdapter);
 
-        cafeteriaViewModel.getError().observe(this, value -> {
-            if (value) {
+        cafeteriaViewModel.getError().observe(this, isError -> {
+            if (isError) {
                 showError(R.string.error_something_wrong);
             } else {
                 showContentLayout();

--- a/app/src/main/java/de/tum/in/tumcampusapp/component/ui/cafeteria/activity/CafeteriaActivity.java
+++ b/app/src/main/java/de/tum/in/tumcampusapp/component/ui/cafeteria/activity/CafeteriaActivity.java
@@ -24,7 +24,6 @@ import androidx.appcompat.app.AlertDialog;
 import androidx.lifecycle.ViewModelProviders;
 import androidx.viewpager.widget.ViewPager;
 import de.tum.in.tumcampusapp.R;
-import de.tum.in.tumcampusapp.api.app.TUMCabeClient;
 import de.tum.in.tumcampusapp.component.other.generic.activity.ActivityForDownloadingExternal;
 import de.tum.in.tumcampusapp.component.other.locations.LocationManager;
 import de.tum.in.tumcampusapp.component.ui.cafeteria.CafeteriaMenuInflater;
@@ -33,7 +32,6 @@ import de.tum.in.tumcampusapp.component.ui.cafeteria.details.CafeteriaDetailsSec
 import de.tum.in.tumcampusapp.component.ui.cafeteria.details.CafeteriaViewModel;
 import de.tum.in.tumcampusapp.component.ui.cafeteria.model.Cafeteria;
 import de.tum.in.tumcampusapp.component.ui.cafeteria.repository.CafeteriaLocalRepository;
-import de.tum.in.tumcampusapp.component.ui.cafeteria.repository.CafeteriaRemoteRepository;
 import de.tum.in.tumcampusapp.database.TcaDb;
 import de.tum.in.tumcampusapp.utils.Const;
 import de.tum.in.tumcampusapp.utils.Utils;
@@ -78,14 +76,10 @@ public class CafeteriaActivity extends ActivityForDownloadingExternal
         initCafeteriaSpinner();
         sectionsPagerAdapter = new CafeteriaDetailsSectionsPagerAdapter(getSupportFragmentManager());
 
-        TUMCabeClient client = TUMCabeClient.getInstance(this);
-        CafeteriaRemoteRepository remoteRepository = new CafeteriaRemoteRepository(client);
-
         TcaDb db = TcaDb.getInstance(this);
         CafeteriaLocalRepository localRepository = new CafeteriaLocalRepository(db);
 
-        CafeteriaViewModel.Factory factory =
-                new CafeteriaViewModel.Factory(localRepository, remoteRepository);
+        CafeteriaViewModel.Factory factory = new CafeteriaViewModel.Factory(localRepository);
         cafeteriaViewModel = ViewModelProviders.of(this, factory).get(CafeteriaViewModel.class);
 
         cafeteriaViewModel.getCafeterias().observe(this, this::updateCafeteria);

--- a/app/src/main/java/de/tum/in/tumcampusapp/component/ui/cafeteria/activity/CafeteriaActivity.java
+++ b/app/src/main/java/de/tum/in/tumcampusapp/component/ui/cafeteria/activity/CafeteriaActivity.java
@@ -110,7 +110,7 @@ public class CafeteriaActivity extends ActivityForDownloadingExternal
 
     private ArrayAdapter<Cafeteria> createArrayAdapter() {
         return new ArrayAdapter<Cafeteria>(
-                this, R.layout.simple_spinner_item_actionbar, android.R.id.text1, mCafeterias) {
+                this, R.layout.simple_spinner_item_actionbar) {
             final LayoutInflater inflater = LayoutInflater.from(getContext());
 
             @Override
@@ -148,7 +148,7 @@ public class CafeteriaActivity extends ActivityForDownloadingExternal
         if (intent != null && intent.hasExtra(Const.MENSA_FOR_FAVORITEDISH)) {
             cafeteriaId = intent.getIntExtra(Const.MENSA_FOR_FAVORITEDISH, NONE_SELECTED);
             intent.removeExtra(Const.MENSA_FOR_FAVORITEDISH);
-        } else if (intent.getExtras() != null && intent.hasExtra(Const.CAFETERIA_ID)) {
+        } else if (intent != null && intent.hasExtra(Const.CAFETERIA_ID)) {
             cafeteriaId = intent.getIntExtra(Const.CAFETERIA_ID, 0);
         } else {
             // If we're not provided with a cafeteria ID, we choose the best matching cafeteria.

--- a/app/src/main/java/de/tum/in/tumcampusapp/component/ui/cafeteria/controller/CafeteriaManager.java
+++ b/app/src/main/java/de/tum/in/tumcampusapp/component/ui/cafeteria/controller/CafeteriaManager.java
@@ -1,31 +1,27 @@
 package de.tum.in.tumcampusapp.component.ui.cafeteria.controller;
 
 import android.content.Context;
-import androidx.annotation.NonNull;
 
 import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 import org.joda.time.DateTime;
 
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
-import de.tum.in.tumcampusapp.api.app.TUMCabeClient;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 import de.tum.in.tumcampusapp.api.tumonline.CacheControl;
 import de.tum.in.tumcampusapp.component.notifications.ProvidesNotifications;
 import de.tum.in.tumcampusapp.component.other.locations.LocationManager;
 import de.tum.in.tumcampusapp.component.ui.cafeteria.CafeteriaMenuCard;
-import de.tum.in.tumcampusapp.component.ui.cafeteria.details.CafeteriaViewModel;
 import de.tum.in.tumcampusapp.component.ui.cafeteria.model.CafeteriaMenu;
 import de.tum.in.tumcampusapp.component.ui.cafeteria.model.CafeteriaWithMenus;
 import de.tum.in.tumcampusapp.component.ui.cafeteria.repository.CafeteriaLocalRepository;
-import de.tum.in.tumcampusapp.component.ui.cafeteria.repository.CafeteriaRemoteRepository;
 import de.tum.in.tumcampusapp.component.ui.overview.card.Card;
 import de.tum.in.tumcampusapp.component.ui.overview.card.ProvidesCard;
 import de.tum.in.tumcampusapp.database.TcaDb;
 import de.tum.in.tumcampusapp.utils.Utils;
-import io.reactivex.disposables.CompositeDisposable;
 
 /**
  * Cafeteria Manager, handles database stuff, external imports
@@ -33,8 +29,8 @@ import io.reactivex.disposables.CompositeDisposable;
 public class CafeteriaManager implements ProvidesCard, ProvidesNotifications {
 
     private Context mContext;
-    private final CafeteriaViewModel cafeteriaViewModel;
-    private final CompositeDisposable compositeDisposable;
+    private LocationManager locationManager;
+    private CafeteriaLocalRepository localRepository;
 
     /**
      * Constructor, open/create database, create table if necessary
@@ -43,13 +39,48 @@ public class CafeteriaManager implements ProvidesCard, ProvidesNotifications {
      */
     public CafeteriaManager(Context context) {
         mContext = context;
-        TcaDb db = TcaDb.getInstance(context);
-        compositeDisposable = new CompositeDisposable();
-        CafeteriaLocalRepository localRepository = CafeteriaLocalRepository.INSTANCE;
-        localRepository.setDb(db);
-        CafeteriaRemoteRepository remoteRepository = CafeteriaRemoteRepository.INSTANCE;
-        remoteRepository.setTumCabeClient(TUMCabeClient.getInstance(context));
-        cafeteriaViewModel = new CafeteriaViewModel(localRepository, remoteRepository, compositeDisposable);
+        locationManager = new LocationManager(context);
+        localRepository = new CafeteriaLocalRepository(TcaDb.getInstance(context));
+    }
+
+    @Override
+    public boolean hasNotificationsEnabled() {
+        return Utils.getSettingBool(mContext, "card_cafeteria_phone", true);
+    }
+
+    /**
+     * Returns a list of {@link CafeteriaMenu}s of the best-matching cafeteria. If there's no
+     * best-matching cafeteria, it returns an empty list.
+     */
+    public List<CafeteriaMenu> getBestMatchCafeteriaMenus() {
+        int cafeteriaId = getBestMatchMensaId();
+        if (cafeteriaId == -1) {
+            return Collections.emptyList();
+        }
+
+        return getCafeteriaMenusByCafeteriaId(cafeteriaId);
+    }
+
+    public int getBestMatchMensaId() {
+        // Choose which mensa should be shown
+        int cafeteriaId = locationManager.getCafeteria();
+        if (cafeteriaId == -1) {
+            Utils.log("could not get a Cafeteria from locationManager!");
+        }
+        return cafeteriaId;
+    }
+
+    private List<CafeteriaMenu> getCafeteriaMenusByCafeteriaId(int cafeteriaId) {
+        CafeteriaWithMenus cafeteria = new CafeteriaWithMenus(cafeteriaId);
+
+        List<DateTime> menuDates = localRepository.getAllMenuDates();
+        cafeteria.setMenuDates(menuDates);
+
+        DateTime nextMenuDate = cafeteria.getNextMenuDate();
+        List<CafeteriaMenu> menus = localRepository.getCafeteriaMenus(cafeteriaId, nextMenuDate);
+        cafeteria.setMenus(menus);
+
+        return cafeteria.getMenus();
     }
 
     @NotNull
@@ -69,11 +100,6 @@ public class CafeteriaManager implements ProvidesCard, ProvidesNotifications {
         return results;
     }
 
-    @Override
-    public boolean hasNotificationsEnabled() {
-        return Utils.getSettingBool(mContext, "card_cafeteria_phone", true);
-    }
-
     @Nullable
     private CafeteriaWithMenus getCafeteriaWithMenus() {
         // Choose which mensa should be shown
@@ -81,43 +107,8 @@ public class CafeteriaManager implements ProvidesCard, ProvidesNotifications {
         if (cafeteriaId == -1) {
             return null;
         }
-        return cafeteriaViewModel.getCafeteriaWithMenus(cafeteriaId);
-    }
 
-    /**
-     * Returns a list of {@link CafeteriaMenu}s of the best-matching cafeteria. If there's no
-     * best-matching cafeteria, it returns an empty list.
-     */
-    public List<CafeteriaMenu> getBestMatchCafeteriaMenus() {
-        int cafeteriaId = getBestMatchMensaId();
-        if (cafeteriaId == -1) {
-            return Collections.emptyList();
-        }
-
-        return getCafeteriaMenusByCafeteriaId(cafeteriaId);
-    }
-
-    public int getBestMatchMensaId() {
-        // Choose which mensa should be shown
-        int cafeteriaId = new LocationManager(mContext).getCafeteria();
-        if (cafeteriaId == -1) {
-            Utils.log("could not get a Cafeteria from locationManager!");
-        }
-        return cafeteriaId;
-    }
-
-    private List<CafeteriaMenu> getCafeteriaMenusByCafeteriaId(int cafeteriaId) {
-        CafeteriaWithMenus cafeteria = new CafeteriaWithMenus(cafeteriaId);
-
-        List<DateTime> menuDates = CafeteriaLocalRepository.INSTANCE.getAllMenuDates();
-        cafeteria.setMenuDates(menuDates);
-
-        DateTime nextMenuDate = cafeteria.getNextMenuDate();
-        List<CafeteriaMenu> menus =
-                CafeteriaLocalRepository.INSTANCE.getCafeteriaMenus(cafeteriaId, nextMenuDate);
-        cafeteria.setMenus(menus);
-
-        return cafeteria.getMenus();
+        return localRepository.getCafeteriaWithMenus(cafeteriaId);
     }
 
 }

--- a/app/src/main/java/de/tum/in/tumcampusapp/component/ui/cafeteria/details/CafeteriaDetailsSectionFragment.java
+++ b/app/src/main/java/de/tum/in/tumcampusapp/component/ui/cafeteria/details/CafeteriaDetailsSectionFragment.java
@@ -18,12 +18,10 @@ import androidx.annotation.Nullable;
 import androidx.core.content.ContextCompat;
 import androidx.fragment.app.Fragment;
 import de.tum.in.tumcampusapp.R;
-import de.tum.in.tumcampusapp.api.app.TUMCabeClient;
 import de.tum.in.tumcampusapp.component.ui.cafeteria.CafeteriaMenuCard;
 import de.tum.in.tumcampusapp.component.ui.cafeteria.CafeteriaMenuInflater;
 import de.tum.in.tumcampusapp.component.ui.cafeteria.model.CafeteriaMenu;
 import de.tum.in.tumcampusapp.component.ui.cafeteria.repository.CafeteriaLocalRepository;
-import de.tum.in.tumcampusapp.component.ui.cafeteria.repository.CafeteriaRemoteRepository;
 import de.tum.in.tumcampusapp.database.TcaDb;
 import de.tum.in.tumcampusapp.utils.Const;
 
@@ -94,13 +92,10 @@ public class CafeteriaDetailsSectionFragment extends Fragment {
     public void onCreate(@Nullable Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
 
-        TUMCabeClient client = TUMCabeClient.getInstance(requireContext());
-        CafeteriaRemoteRepository remoteRepository = new CafeteriaRemoteRepository(client);
-
         TcaDb database = TcaDb.getInstance(requireContext());
         CafeteriaLocalRepository localRepository = new CafeteriaLocalRepository(database);
 
-        cafeteriaViewModel = new CafeteriaViewModel(localRepository, remoteRepository);
+        cafeteriaViewModel = new CafeteriaViewModel(localRepository);
     }
 
     @Override

--- a/app/src/main/java/de/tum/in/tumcampusapp/component/ui/cafeteria/details/CafeteriaDetailsSectionFragment.java
+++ b/app/src/main/java/de/tum/in/tumcampusapp/component/ui/cafeteria/details/CafeteriaDetailsSectionFragment.java
@@ -2,10 +2,6 @@ package de.tum.in.tumcampusapp.component.ui.cafeteria.details;
 
 import android.content.Context;
 import android.os.Bundle;
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
-import androidx.fragment.app.Fragment;
-import androidx.core.content.ContextCompat;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -14,10 +10,13 @@ import android.widget.TextView;
 
 import org.joda.time.DateTime;
 import org.joda.time.format.DateTimeFormat;
-import org.joda.time.format.DateTimeFormatter;
 
 import java.util.List;
 
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.core.content.ContextCompat;
+import androidx.fragment.app.Fragment;
 import de.tum.in.tumcampusapp.R;
 import de.tum.in.tumcampusapp.api.app.TUMCabeClient;
 import de.tum.in.tumcampusapp.component.ui.cafeteria.CafeteriaMenuCard;
@@ -27,8 +26,6 @@ import de.tum.in.tumcampusapp.component.ui.cafeteria.repository.CafeteriaLocalRe
 import de.tum.in.tumcampusapp.component.ui.cafeteria.repository.CafeteriaRemoteRepository;
 import de.tum.in.tumcampusapp.database.TcaDb;
 import de.tum.in.tumcampusapp.utils.Const;
-import de.tum.in.tumcampusapp.utils.DateTimeUtils;
-import io.reactivex.disposables.CompositeDisposable;
 
 /**
  * Fragment for each cafeteria-page.
@@ -36,7 +33,15 @@ import io.reactivex.disposables.CompositeDisposable;
 public class CafeteriaDetailsSectionFragment extends Fragment {
 
     private CafeteriaViewModel cafeteriaViewModel;
-    private final CompositeDisposable mDisposable = new CompositeDisposable();
+
+    public static CafeteriaDetailsSectionFragment newInstance(int cafeteriaId, DateTime dateTime) {
+        CafeteriaDetailsSectionFragment fragment = new CafeteriaDetailsSectionFragment();
+        Bundle args = new Bundle();
+        args.putSerializable(Const.DATE, dateTime);
+        args.putInt(Const.CAFETERIA_ID, cafeteriaId);
+        fragment.setArguments(args);
+        return fragment;
+    }
 
     /**
      * Inflates the cafeteria menu layout.
@@ -53,28 +58,16 @@ public class CafeteriaDetailsSectionFragment extends Fragment {
         final Context context = rootView.getContext();
 
         if (!isBigLayout) {
-            // Show opening hours
-            OpenHoursHelper lm = new OpenHoursHelper(context);
-
-            TextView textview;
-            textview = new TextView(context, null, R.style.CardBody);
-            textview.setText(lm.getHoursByIdAsString(context, cafeteriaId, date));
-            textview.setTextColor(ContextCompat.getColor(context, R.color.sections_green));
-
-            int bottomPadding = context.getResources()
-                    .getDimensionPixelOffset(R.dimen.material_default_padding);
-            textview.setPadding(0, 0, 0, bottomPadding);
-
-            rootView.addView(textview);
+            TextView textView = createOpeningHoursTextView(context, cafeteriaId, date);
+            rootView.addView(textView);
         }
 
         // Show cafeteria menu
-        String curShort = "";
-        CafeteriaMenuInflater menuInflater =
-                new CafeteriaMenuInflater(context, rootView, isBigLayout);
+        String currentCafeteriaMenuType = "";
+        CafeteriaMenuInflater menuInflater = new CafeteriaMenuInflater(context, rootView, isBigLayout);
 
         for (CafeteriaMenu cafeteriaMenu : cafeteriaMenus) {
-            boolean isFirstInSection = !cafeteriaMenu.getTypeShort().equals(curShort);
+            boolean isFirstInSection = !cafeteriaMenu.getTypeShort().equals(currentCafeteriaMenuType);
             View view = menuInflater.inflate(cafeteriaMenu, isFirstInSection);
 
             if (view != null) {
@@ -83,58 +76,54 @@ public class CafeteriaDetailsSectionFragment extends Fragment {
         }
     }
 
+    private static TextView createOpeningHoursTextView(Context context, int cafeteriaId, DateTime date) {
+        OpenHoursHelper lm = new OpenHoursHelper(context);
+
+        TextView textview;
+        textview = new TextView(context, null, R.style.CardBody);
+        textview.setText(lm.getHoursByIdAsString(context, cafeteriaId, date));
+        textview.setTextColor(ContextCompat.getColor(context, R.color.sections_green));
+
+        int bottomPadding = context.getResources()
+                .getDimensionPixelOffset(R.dimen.material_default_padding);
+        textview.setPadding(0, 0, 0, bottomPadding);
+        return textview;
+    }
+
     @Override
     public void onCreate(@Nullable Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
 
-        CafeteriaRemoteRepository remoteRepository = CafeteriaRemoteRepository.INSTANCE;
-        remoteRepository.setTumCabeClient(TUMCabeClient.getInstance(getContext()));
+        TUMCabeClient client = TUMCabeClient.getInstance(requireContext());
+        CafeteriaRemoteRepository remoteRepository = new CafeteriaRemoteRepository(client);
 
-        CafeteriaLocalRepository localRepository = CafeteriaLocalRepository.INSTANCE;
-        localRepository.setDb(TcaDb.getInstance(getContext()));
+        TcaDb database = TcaDb.getInstance(requireContext());
+        CafeteriaLocalRepository localRepository = new CafeteriaLocalRepository(database);
 
-        cafeteriaViewModel = new CafeteriaViewModel(localRepository, remoteRepository, mDisposable);
+        cafeteriaViewModel = new CafeteriaViewModel(localRepository, remoteRepository);
     }
 
     @Override
     public View onCreateView(@NonNull LayoutInflater inflater,
                              ViewGroup container, Bundle savedInstanceState) {
-        final View rootView = inflater.inflate(
-                R.layout.fragment_cafeteriadetails_section, container, false);
-
-        if (getArguments() == null) {
-            return rootView;
-        }
-
-        String dateString = getArguments().getString(Const.DATE);
-        if (dateString == null) {
-            return rootView;
-        }
-
-        DateTimeFormatter formatter = DateTimeFormat.fullDate();
-        DateTime menuDate = DateTimeUtils.INSTANCE.getDate(dateString);
-        String menuDateString = formatter.print(menuDate);
-
-        TextView dateTextView = rootView.findViewById(R.id.menuDateTextView);
-        dateTextView.setText(menuDateString);
-
-        LinearLayout root = rootView.findViewById(R.id.layout);
-        int cafeteriaId = getArguments().getInt(Const.CAFETERIA_ID);
-        DateTime date = DateTimeUtils.INSTANCE.getDate(dateString);
-
-        mDisposable.add(
-                cafeteriaViewModel
-                        .getCafeteriaMenus(cafeteriaId, date)
-                        .subscribe(menu -> showMenu(root, cafeteriaId, date, true, menu))
-        );
-
-        return rootView;
+        return inflater.inflate(R.layout.fragment_cafeteriadetails_section, container, false);
     }
 
     @Override
-    public void onDestroy() {
-        super.onDestroy();
-        mDisposable.dispose();
-    }
+    public void onViewCreated(@NonNull View view, @Nullable Bundle savedInstanceState) {
+        DateTime menuDate = (DateTime) getArguments().getSerializable(Const.DATE);
+        String menuDateString = DateTimeFormat.fullDate().print(menuDate);
 
+        TextView dateTextView = view.findViewById(R.id.menuDateTextView);
+        dateTextView.setText(menuDateString);
+
+        LinearLayout root = view.findViewById(R.id.layout);
+        int cafeteriaId = getArguments().getInt(Const.CAFETERIA_ID);
+
+        cafeteriaViewModel.getCafeteriaMenus().observe(getViewLifecycleOwner(), cafeteriaMenus -> {
+            showMenu(root, cafeteriaId, menuDate, true, cafeteriaMenus);
+        });
+
+        cafeteriaViewModel.fetchCafeteriaMenus(cafeteriaId, menuDate);
+    }
 }

--- a/app/src/main/java/de/tum/in/tumcampusapp/component/ui/cafeteria/details/CafeteriaDetailsSectionsPagerAdapter.java
+++ b/app/src/main/java/de/tum/in/tumcampusapp/component/ui/cafeteria/details/CafeteriaDetailsSectionsPagerAdapter.java
@@ -1,59 +1,39 @@
 package de.tum.in.tumcampusapp.component.ui.cafeteria.details;
 
-import android.content.Context;
-import android.os.Bundle;
-import androidx.annotation.NonNull;
-import androidx.fragment.app.Fragment;
-import androidx.fragment.app.FragmentManager;
-import androidx.fragment.app.FragmentStatePagerAdapter;
-
 import org.joda.time.DateTime;
 import org.joda.time.format.DateTimeFormat;
 import org.joda.time.format.DateTimeFormatter;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
 
-import de.tum.in.tumcampusapp.api.app.TUMCabeClient;
-import de.tum.in.tumcampusapp.component.ui.cafeteria.repository.CafeteriaLocalRepository;
-import de.tum.in.tumcampusapp.component.ui.cafeteria.repository.CafeteriaRemoteRepository;
-import de.tum.in.tumcampusapp.database.TcaDb;
-import de.tum.in.tumcampusapp.utils.Const;
-import de.tum.in.tumcampusapp.utils.DateTimeUtils;
-import io.reactivex.disposables.CompositeDisposable;
-import io.reactivex.disposables.Disposable;
+import androidx.annotation.NonNull;
+import androidx.fragment.app.Fragment;
+import androidx.fragment.app.FragmentManager;
+import androidx.fragment.app.FragmentStatePagerAdapter;
 
 /**
  * A {@link FragmentStatePagerAdapter} that returns a fragment corresponding to one
  * of the sections/tabs/pages.
  */
 public class CafeteriaDetailsSectionsPagerAdapter extends FragmentStatePagerAdapter {
-    private int mCafeteriaId;
 
-    private List<DateTime> dates = new ArrayList<>();
-
-    private final CompositeDisposable mDisposable = new CompositeDisposable();
+    private int cafeteriaId;
+    private List<DateTime> dates;
+    private DateTimeFormatter formatter;
 
     public CafeteriaDetailsSectionsPagerAdapter(FragmentManager fm) {
         super(fm);
+        formatter = DateTimeFormat.fullDate();
     }
 
-    public void setCafeteriaId(Context context, int cafeteriaId) {
-        mCafeteriaId = cafeteriaId;
-        CafeteriaRemoteRepository remoteRepository = CafeteriaRemoteRepository.INSTANCE;
-        remoteRepository.setTumCabeClient(TUMCabeClient.getInstance(context));
-        CafeteriaLocalRepository localRepository = CafeteriaLocalRepository.INSTANCE;
-        localRepository.setDb(TcaDb.getInstance(context));
-        CafeteriaViewModel cafeteriaViewModel = new CafeteriaViewModel(localRepository, remoteRepository, mDisposable);
-        Disposable getAllMenuDates = cafeteriaViewModel.getAllMenuDates()
-                .subscribe(dates -> {
-                    this.dates = dates;
-                    this.notifyDataSetChanged();
-                });
-        mDisposable.add(getAllMenuDates);
-        // Tell we just update the data
+    public void setCafeteriaId(int cafeteriaId) {
+        this.cafeteriaId = cafeteriaId;
+    }
 
+    public void update(List<DateTime> menuDates) {
+        dates = menuDates;
+        notifyDataSetChanged();
     }
 
     @Override
@@ -63,25 +43,19 @@ public class CafeteriaDetailsSectionsPagerAdapter extends FragmentStatePagerAdap
 
     @Override
     public Fragment getItem(int position) {
-        // getItem is called to instantiate the fragment for the given page.
-        Fragment fragment = new CafeteriaDetailsSectionFragment();
-        Bundle args = new Bundle();
-        args.putString(Const.DATE, DateTimeUtils.INSTANCE.getDateString(dates.get(position)));
-        args.putInt(Const.CAFETERIA_ID, mCafeteriaId);
-        fragment.setArguments(args);
-        return fragment;
+        DateTime dateTime = dates.get(position);
+        return CafeteriaDetailsSectionFragment.newInstance(cafeteriaId, dateTime);
     }
 
     @Override
     public CharSequence getPageTitle(int position) {
-        DateTimeFormatter format = DateTimeFormat.fullDate();
         DateTime date = dates.get(position);
-
-        return format.print(date).toUpperCase(Locale.getDefault());
+        return formatter.print(date).toUpperCase(Locale.getDefault());
     }
 
     @Override
     public int getItemPosition(@NonNull Object object) {
         return POSITION_NONE;
     }
+
 }

--- a/app/src/main/java/de/tum/in/tumcampusapp/component/ui/cafeteria/details/CafeteriaViewModel.kt
+++ b/app/src/main/java/de/tum/in/tumcampusapp/component/ui/cafeteria/details/CafeteriaViewModel.kt
@@ -1,46 +1,98 @@
 package de.tum.`in`.tumcampusapp.component.ui.cafeteria.details
 
-import androidx.lifecycle.ViewModel
 import android.location.Location
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
 import de.tum.`in`.tumcampusapp.component.ui.cafeteria.model.Cafeteria
 import de.tum.`in`.tumcampusapp.component.ui.cafeteria.model.CafeteriaMenu
 import de.tum.`in`.tumcampusapp.component.ui.cafeteria.model.CafeteriaWithMenus
 import de.tum.`in`.tumcampusapp.component.ui.cafeteria.repository.CafeteriaLocalRepository
 import de.tum.`in`.tumcampusapp.component.ui.cafeteria.repository.CafeteriaRemoteRepository
+import de.tum.`in`.tumcampusapp.utils.LocationHelper
 import de.tum.`in`.tumcampusapp.utils.Utils
+import de.tum.`in`.tumcampusapp.utils.plusAssign
 import io.reactivex.Flowable
 import io.reactivex.Observable
-import io.reactivex.android.schedulers.AndroidSchedulers
 import io.reactivex.disposables.CompositeDisposable
 import io.reactivex.schedulers.Schedulers
 import org.joda.time.DateTime
 
-/**
- * ViewModel for cafeterias.
- */
-class CafeteriaViewModel(private val localRepository: CafeteriaLocalRepository,
-                         private val remoteRepository: CafeteriaRemoteRepository,
-                         private val compositeDisposable: CompositeDisposable) : ViewModel() {
+class CafeteriaViewModel(
+        private val localRepository: CafeteriaLocalRepository,
+        private val remoteRepository: CafeteriaRemoteRepository
+) : ViewModel() {
+
+    private val _cafeterias = MutableLiveData<List<Cafeteria>>()
+    val cafeterias: LiveData<List<Cafeteria>> = _cafeterias
+
+    private val _selectedCafeteria = MutableLiveData<Cafeteria>()
+    val selectedCafeteria: LiveData<Cafeteria> = _selectedCafeteria
+
+    private val _cafeteriaMenus = MutableLiveData<List<CafeteriaMenu>>()
+    val cafeteriaMenus: LiveData<List<CafeteriaMenu>> = _cafeteriaMenus
+
+    private val _menuDates = MutableLiveData<List<DateTime>>()
+    val menuDates: LiveData<List<DateTime>> = _menuDates
+
+    private val _error = MutableLiveData<Boolean>()
+    val error: LiveData<Boolean> = _error
+
+    private val compositeDisposable = CompositeDisposable()
+
+    fun updateSelectedCafeteria(cafeteria: Cafeteria) {
+        _selectedCafeteria.postValue(cafeteria)
+    }
+
+    fun fetchCafeterias(location: Location) {
+        compositeDisposable += getAllCafeterias(location)
+                .doOnError { _error.postValue(true) }
+                .doOnNext { _error.postValue(it.isEmpty()) }
+                .subscribe({
+                    _cafeterias.postValue(it)
+                }, {
+                    t -> Utils.log(t)
+                })
+    }
+
+    fun fetchMenuDates() {
+        compositeDisposable += fetchAllMenuDates()
+                .subscribe(_menuDates::postValue, Utils::log)
+    }
+
+    private fun fetchAllMenuDates(): Flowable<List<DateTime>> {
+        return Flowable
+                .fromCallable { localRepository.getAllMenuDates() }
+                .subscribeOn(Schedulers.io())
+                .defaultIfEmpty(emptyList())
+    }
 
     /**
      * Returns a flowable that emits a list of cafeterias from the local repository.
      */
-    fun getAllCafeterias(location: Location): Flowable<List<Cafeteria>> =
-            localRepository.getAllCafeterias()
-                    .subscribeOn(Schedulers.io())
-                    .observeOn(AndroidSchedulers.mainThread())
-                    .map { transformCafeteria(it, location) }
-                    .defaultIfEmpty(emptyList())
+    private fun getAllCafeterias(location: Location): Flowable<List<Cafeteria>> {
+        return localRepository.getAllCafeterias()
+                .map { transformCafeteria(it, location) }
+                .subscribeOn(Schedulers.io())
+                .defaultIfEmpty(emptyList())
+    }
 
     fun getCafeteriaWithMenus(cafeteriaId: Int): CafeteriaWithMenus {
         return localRepository.getCafeteriaWithMenus(cafeteriaId)
+    }
+
+    fun fetchCafeteriaMenus(id: Int, date: DateTime) {
+        compositeDisposable += Flowable.fromCallable { localRepository.getCafeteriaMenus(id, date) }
+                .subscribeOn(Schedulers.io())
+                .defaultIfEmpty(emptyList())
+                .subscribe { _cafeteriaMenus.postValue(it) }
     }
 
     fun getCafeteriaMenus(id: Int, date: DateTime): Flowable<List<CafeteriaMenu>> {
         return Flowable
                 .fromCallable { localRepository.getCafeteriaMenus(id, date) }
                 .subscribeOn(Schedulers.io())
-                .observeOn(AndroidSchedulers.mainThread())
                 .defaultIfEmpty(emptyList())
     }
 
@@ -48,7 +100,6 @@ class CafeteriaViewModel(private val localRepository: CafeteriaLocalRepository,
         return Flowable
                 .fromCallable { localRepository.getAllMenuDates() }
                 .subscribeOn(Schedulers.io())
-                .observeOn(AndroidSchedulers.mainThread())
                 .defaultIfEmpty(emptyList())
     }
 
@@ -62,27 +113,45 @@ class CafeteriaViewModel(private val localRepository: CafeteriaLocalRepository,
      * Lastly updates last sync
      *
      */
-    fun getCafeteriasFromService(force: Boolean): Boolean =
-            compositeDisposable.add(Observable.just(1)
-                    .filter { localRepository.getLastSync() == null || force }
-                    .subscribeOn(Schedulers.computation())
-                    .observeOn(Schedulers.io())
-                    .doOnNext { localRepository.clear() }
-                    .flatMap { remoteRepository.getAllCafeterias() }
-                    .doAfterNext { localRepository.updateLastSync() }
-                    .subscribe({ cafeteria ->
-                        cafeteria.forEach { localRepository.addCafeteria(it) }
-                    }, { throwable -> Utils.log(throwable) })
-            )
+    fun getCafeteriasFromService(force: Boolean) {
+        compositeDisposable += Observable
+                .fromCallable { localRepository.getLastSync() == null || force }
+                .doOnNext { localRepository.clear() }
+                .doAfterNext { localRepository.updateLastSync() }
+                .flatMap { remoteRepository.getAllCafeterias() }
+                .subscribeOn(Schedulers.io())
+                .subscribe({
+                    localRepository.addCafeterias(it)
+                }, {
+                    throwable -> Utils.log(throwable)
+                })
+    }
 
     /**
      * Adds the distance between user and cafeteria to model.
      */
-    private fun transformCafeteria(cafeterias: List<Cafeteria>, location: Location): List<Cafeteria> =
-            cafeterias.map {
-                val results = FloatArray(1)
-                Location.distanceBetween(it.latitude, it.longitude, location.latitude, location.longitude, results)
-                it.distance = results[0]
-                it
-            }
+    private fun transformCafeteria(cafeterias: List<Cafeteria>, location: Location): List<Cafeteria> {
+        return cafeterias.map {
+            it.distance = LocationHelper.calculateDistanceToCafeteria(it, location)
+            it
+        }
+    }
+
+    override fun onCleared() {
+        super.onCleared()
+        compositeDisposable.dispose()
+    }
+
+    class Factory(
+            private val localRepository: CafeteriaLocalRepository,
+            private val remoteRepository: CafeteriaRemoteRepository
+    ) : ViewModelProvider.Factory {
+
+        @Suppress("UNCHECKED_CAST") // no good way around this
+        override fun <T : ViewModel?> create(modelClass: Class<T>): T {
+            return CafeteriaViewModel(localRepository, remoteRepository) as T
+        }
+
+    }
+
 }

--- a/app/src/main/java/de/tum/in/tumcampusapp/component/ui/cafeteria/details/CafeteriaViewModel.kt
+++ b/app/src/main/java/de/tum/in/tumcampusapp/component/ui/cafeteria/details/CafeteriaViewModel.kt
@@ -48,16 +48,19 @@ class CafeteriaViewModel(
         compositeDisposable += getAllCafeterias(location)
                 .doOnError { _error.postValue(true) }
                 .doOnNext { _error.postValue(it.isEmpty()) }
-                .subscribe({
-                    _cafeterias.postValue(it)
-                }, {
-                    t -> Utils.log(t)
-                })
+                .subscribe(_cafeterias::postValue, Utils::log)
     }
 
     fun fetchMenuDates() {
         compositeDisposable += fetchAllMenuDates()
                 .subscribe(_menuDates::postValue, Utils::log)
+    }
+
+    fun fetchCafeteriaMenus(id: Int, date: DateTime) {
+        compositeDisposable += Flowable.fromCallable { localRepository.getCafeteriaMenus(id, date) }
+                .subscribeOn(Schedulers.io())
+                .defaultIfEmpty(emptyList())
+                .subscribe { _cafeteriaMenus.postValue(it) }
     }
 
     private fun fetchAllMenuDates(): Flowable<List<DateTime>> {
@@ -75,13 +78,6 @@ class CafeteriaViewModel(
                 .map { transformCafeteria(it, location) }
                 .subscribeOn(Schedulers.io())
                 .defaultIfEmpty(emptyList())
-    }
-
-    fun fetchCafeteriaMenus(id: Int, date: DateTime) {
-        compositeDisposable += Flowable.fromCallable { localRepository.getCafeteriaMenus(id, date) }
-                .subscribeOn(Schedulers.io())
-                .defaultIfEmpty(emptyList())
-                .subscribe { _cafeteriaMenus.postValue(it) }
     }
 
     /**

--- a/app/src/main/java/de/tum/in/tumcampusapp/component/ui/cafeteria/details/CafeteriaViewModel.kt
+++ b/app/src/main/java/de/tum/in/tumcampusapp/component/ui/cafeteria/details/CafeteriaViewModel.kt
@@ -7,7 +7,6 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import de.tum.`in`.tumcampusapp.component.ui.cafeteria.model.Cafeteria
 import de.tum.`in`.tumcampusapp.component.ui.cafeteria.model.CafeteriaMenu
-import de.tum.`in`.tumcampusapp.component.ui.cafeteria.model.CafeteriaWithMenus
 import de.tum.`in`.tumcampusapp.component.ui.cafeteria.repository.CafeteriaLocalRepository
 import de.tum.`in`.tumcampusapp.component.ui.cafeteria.repository.CafeteriaRemoteRepository
 import de.tum.`in`.tumcampusapp.utils.LocationHelper
@@ -78,31 +77,12 @@ class CafeteriaViewModel(
                 .defaultIfEmpty(emptyList())
     }
 
-    fun getCafeteriaWithMenus(cafeteriaId: Int): CafeteriaWithMenus {
-        return localRepository.getCafeteriaWithMenus(cafeteriaId)
-    }
-
     fun fetchCafeteriaMenus(id: Int, date: DateTime) {
         compositeDisposable += Flowable.fromCallable { localRepository.getCafeteriaMenus(id, date) }
                 .subscribeOn(Schedulers.io())
                 .defaultIfEmpty(emptyList())
                 .subscribe { _cafeteriaMenus.postValue(it) }
     }
-
-    fun getCafeteriaMenus(id: Int, date: DateTime): Flowable<List<CafeteriaMenu>> {
-        return Flowable
-                .fromCallable { localRepository.getCafeteriaMenus(id, date) }
-                .subscribeOn(Schedulers.io())
-                .defaultIfEmpty(emptyList())
-    }
-
-    fun getAllMenuDates(): Flowable<List<DateTime>> {
-        return Flowable
-                .fromCallable { localRepository.getAllMenuDates() }
-                .subscribeOn(Schedulers.io())
-                .defaultIfEmpty(emptyList())
-    }
-
 
     /**
      * Downloads cafeterias and stores them in the local repository.

--- a/app/src/main/java/de/tum/in/tumcampusapp/component/ui/cafeteria/model/Cafeteria.kt
+++ b/app/src/main/java/de/tum/in/tumcampusapp/component/ui/cafeteria/model/Cafeteria.kt
@@ -15,15 +15,17 @@ import androidx.room.RoomWarnings
  */
 @Entity
 @SuppressWarnings(RoomWarnings.DEFAULT_CONSTRUCTOR)
-data class Cafeteria(@field:PrimaryKey
-                     var id: Int = -1,
-                     var name: String = "",
-                     var address: String = "",
-                     var latitude: Double = -1.0,
-                     var longitude: Double = -1.0) : Comparable<Cafeteria> {
+data class Cafeteria(
+        @field:PrimaryKey
+        var id: Int = -1,
+        var name: String = "",
+        var address: String = "",
+        var latitude: Double = -1.0,
+        var longitude: Double = -1.0
+) : Comparable<Cafeteria> {
 
     // Used for ordering cafeterias
-    var distance: Float = 0.toFloat()
+    var distance: Float = 0f
 
     override fun toString(): String = name
 

--- a/app/src/main/java/de/tum/in/tumcampusapp/component/ui/cafeteria/repository/CafeteriaLocalRepository.kt
+++ b/app/src/main/java/de/tum/in/tumcampusapp/component/ui/cafeteria/repository/CafeteriaLocalRepository.kt
@@ -7,17 +7,10 @@ import de.tum.`in`.tumcampusapp.component.ui.cafeteria.model.CafeteriaWithMenus
 import de.tum.`in`.tumcampusapp.database.TcaDb
 import de.tum.`in`.tumcampusapp.utils.sync.model.Sync
 import io.reactivex.Flowable
+import org.jetbrains.anko.doAsync
 import org.joda.time.DateTime
-import java.util.concurrent.Executor
-import java.util.concurrent.Executors
 
-object CafeteriaLocalRepository {
-
-    private const val TIME_TO_SYNC = 604800
-
-    private val executor: Executor = Executors.newSingleThreadExecutor()
-
-    lateinit var db: TcaDb
+class CafeteriaLocalRepository(private val db: TcaDb) {
 
     fun getCafeteriaWithMenus(cafeteriaId: Int): CafeteriaWithMenus {
         return CafeteriaWithMenus(cafeteriaId).apply {
@@ -44,8 +37,11 @@ object CafeteriaLocalRepository {
 
     fun getCafeteria(id: Int): Cafeteria? = db.cafeteriaDao().getById(id)
 
-    fun addCafeteria(cafeteria: Cafeteria) = executor.execute { db.cafeteriaDao().insert(cafeteria) }
-
+    fun addCafeterias(cafeterias: List<Cafeteria>) {
+        doAsync {
+            db.cafeteriaDao().insert(*cafeterias.toTypedArray())
+        }
+    }
 
     // Sync methods //
 
@@ -55,6 +51,8 @@ object CafeteriaLocalRepository {
 
     fun clear() = db.cafeteriaDao().removeCache()
 
+    companion object {
+        private const val TIME_TO_SYNC = 604800
+    }
+
 }
-
-

--- a/app/src/main/java/de/tum/in/tumcampusapp/component/ui/cafeteria/repository/CafeteriaRemoteRepository.kt
+++ b/app/src/main/java/de/tum/in/tumcampusapp/component/ui/cafeteria/repository/CafeteriaRemoteRepository.kt
@@ -4,9 +4,7 @@ import de.tum.`in`.tumcampusapp.api.app.TUMCabeClient
 import de.tum.`in`.tumcampusapp.component.ui.cafeteria.model.Cafeteria
 import io.reactivex.Observable
 
-object CafeteriaRemoteRepository {
-
-    lateinit var tumCabeClient: TUMCabeClient
+class CafeteriaRemoteRepository(private val tumCabeClient: TUMCabeClient) {
 
     fun getAllCafeterias(): Observable<List<Cafeteria>> = tumCabeClient.cafeterias
 

--- a/app/src/main/java/de/tum/in/tumcampusapp/component/ui/cafeteria/repository/CafeteriaRemoteRepository.kt
+++ b/app/src/main/java/de/tum/in/tumcampusapp/component/ui/cafeteria/repository/CafeteriaRemoteRepository.kt
@@ -1,11 +1,33 @@
 package de.tum.`in`.tumcampusapp.component.ui.cafeteria.repository
 
+import android.annotation.SuppressLint
 import de.tum.`in`.tumcampusapp.api.app.TUMCabeClient
-import de.tum.`in`.tumcampusapp.component.ui.cafeteria.model.Cafeteria
+import de.tum.`in`.tumcampusapp.utils.Utils
 import io.reactivex.Observable
+import io.reactivex.schedulers.Schedulers
 
-class CafeteriaRemoteRepository(private val tumCabeClient: TUMCabeClient) {
+class CafeteriaRemoteRepository(
+        private val tumCabeClient: TUMCabeClient,
+        private val localRepository: CafeteriaLocalRepository
+) {
 
-    fun getAllCafeterias(): Observable<List<Cafeteria>> = tumCabeClient.cafeterias
+    /**
+     * Downloads cafeterias and stores them in the local repository.
+     *
+     * First checks whether a sync is necessary
+     * Then clears current cache
+     * Insert new cafeterias
+     * Lastly updates last sync
+     *
+     */
+    @SuppressLint("CheckResult")
+    fun fetchCafeterias(force: Boolean) {
+        Observable.fromCallable { localRepository.getLastSync() == null || force }
+                .doOnNext { localRepository.clear() }
+                .doAfterNext { localRepository.updateLastSync() }
+                .flatMap { tumCabeClient.cafeterias }
+                .subscribeOn(Schedulers.io())
+                .subscribe(localRepository::addCafeterias, Utils::log)
+    }
 
 }

--- a/app/src/main/java/de/tum/in/tumcampusapp/component/ui/cafeteria/widget/MensaWidget.java
+++ b/app/src/main/java/de/tum/in/tumcampusapp/component/ui/cafeteria/widget/MensaWidget.java
@@ -27,15 +27,18 @@ import de.tum.in.tumcampusapp.utils.Const;
  */
 public class MensaWidget extends AppWidgetProvider {
 
+    private CafeteriaLocalRepository localRepository;
+
     @Override
     public void onUpdate(Context context, AppWidgetManager appWidgetManager, int[] appWidgetIds) {
+        TcaDb tcaDb = TcaDb.getInstance(context);
+        localRepository = new CafeteriaLocalRepository(tcaDb);
+
         for (int appWidgetId : appWidgetIds) {
             RemoteViews rv = new RemoteViews(context.getPackageName(), R.layout.mensa_widget);
 
             // Set the header for the Widget layout
             CafeteriaManager mensaManager = new CafeteriaManager(context);
-            CafeteriaLocalRepository localRepository = CafeteriaLocalRepository.INSTANCE;
-            localRepository.setDb(TcaDb.getInstance(context));
 
             int cafeteriaId = mensaManager.getBestMatchMensaId();
             Cafeteria cafeteria = localRepository.getCafeteria(cafeteriaId);
@@ -68,5 +71,3 @@ public class MensaWidget extends AppWidgetProvider {
     }
 
 }
-
-

--- a/app/src/main/java/de/tum/in/tumcampusapp/service/DownloadService.kt
+++ b/app/src/main/java/de/tum/in/tumcampusapp/service/DownloadService.kt
@@ -10,7 +10,6 @@ import de.tum.`in`.tumcampusapp.api.app.TUMCabeClient
 import de.tum.`in`.tumcampusapp.api.app.model.UploadStatus
 import de.tum.`in`.tumcampusapp.api.tumonline.AccessTokenManager
 import de.tum.`in`.tumcampusapp.component.ui.cafeteria.controller.CafeteriaMenuManager
-import de.tum.`in`.tumcampusapp.component.ui.cafeteria.details.CafeteriaViewModel
 import de.tum.`in`.tumcampusapp.component.ui.cafeteria.model.Location
 import de.tum.`in`.tumcampusapp.component.ui.cafeteria.repository.CafeteriaLocalRepository
 import de.tum.`in`.tumcampusapp.component.ui.cafeteria.repository.CafeteriaRemoteRepository
@@ -36,7 +35,7 @@ import java.io.IOException
 class DownloadService : JobIntentService() {
 
     private lateinit var broadcastManager: LocalBroadcastManager
-    private lateinit var cafeteriaViewModel: CafeteriaViewModel
+    private lateinit var cafeteriaRemoteRepository: CafeteriaRemoteRepository
 
     private lateinit var kinoViewModel: KinoViewModel
     private lateinit var topNewsViewModel: TopNewsViewModel
@@ -55,9 +54,8 @@ class DownloadService : JobIntentService() {
         tumCabeClient = TUMCabeClient.getInstance(this)
         database = TcaDb.getInstance(this)
 
-        val remoteRepository = CafeteriaRemoteRepository(tumCabeClient)
         val localRepository = CafeteriaLocalRepository(database)
-        cafeteriaViewModel = CafeteriaViewModel(localRepository, remoteRepository)
+        cafeteriaRemoteRepository = CafeteriaRemoteRepository(tumCabeClient, localRepository)
 
         // Init sync table
         KinoLocalRepository.db = database
@@ -140,7 +138,7 @@ class DownloadService : JobIntentService() {
 
     private fun downloadCafeterias(force: Boolean): Boolean {
         CafeteriaMenuManager(this).downloadMenus(force)
-        cafeteriaViewModel.getCafeteriasFromService(force)
+        cafeteriaRemoteRepository.fetchCafeterias(force)
         return true
     }
 

--- a/app/src/main/java/de/tum/in/tumcampusapp/service/DownloadService.kt
+++ b/app/src/main/java/de/tum/in/tumcampusapp/service/DownloadService.kt
@@ -55,12 +55,9 @@ class DownloadService : JobIntentService() {
         tumCabeClient = TUMCabeClient.getInstance(this)
         database = TcaDb.getInstance(this)
 
-        val remoteRepository = CafeteriaRemoteRepository
-        remoteRepository.tumCabeClient = tumCabeClient
-
-        val localRepository = CafeteriaLocalRepository
-        localRepository.db = database
-        cafeteriaViewModel = CafeteriaViewModel(localRepository, remoteRepository, disposable)
+        val remoteRepository = CafeteriaRemoteRepository(tumCabeClient)
+        val localRepository = CafeteriaLocalRepository(database)
+        cafeteriaViewModel = CafeteriaViewModel(localRepository, remoteRepository)
 
         // Init sync table
         KinoLocalRepository.db = database
@@ -111,7 +108,7 @@ class DownloadService : JobIntentService() {
 
     /**
      * asks to verify private key, uploads fcm token and obfuscated ids (if missing)
-    */
+     */
     private fun uploadMissingIds() {
         val lrzId = Utils.getSetting(this, Const.LRZ_ID, "")
 

--- a/app/src/main/java/de/tum/in/tumcampusapp/utils/Extensions.kt
+++ b/app/src/main/java/de/tum/in/tumcampusapp/utils/Extensions.kt
@@ -17,6 +17,8 @@ import android.widget.TextView
 import com.squareup.picasso.Callback
 import com.squareup.picasso.RequestCreator
 import de.tum.`in`.tumcampusapp.component.other.generic.drawer.SideNavigationItem
+import io.reactivex.disposables.CompositeDisposable
+import io.reactivex.disposables.Disposable
 
 /**
  * Executes the block and return null in case of an [Exception].
@@ -124,4 +126,8 @@ fun TextView.addCompoundDrawablesWithIntrinsicBounds(
 fun TextView.addCompoundDrawablesWithIntrinsicBounds(
         start: Int = 0, top: Int = 0, right: Int = 0, bottom: Int = 0) {
     setCompoundDrawablesWithIntrinsicBounds(start, top, right, bottom)
+}
+
+operator fun CompositeDisposable.plusAssign(disposable: Disposable) {
+    this.add(disposable)
 }

--- a/app/src/main/java/de/tum/in/tumcampusapp/utils/LocationHelper.kt
+++ b/app/src/main/java/de/tum/in/tumcampusapp/utils/LocationHelper.kt
@@ -1,0 +1,15 @@
+package de.tum.`in`.tumcampusapp.utils
+
+import android.location.Location
+import de.tum.`in`.tumcampusapp.component.ui.cafeteria.model.Cafeteria
+
+object LocationHelper {
+
+    fun calculateDistanceToCafeteria(cafeteria: Cafeteria, location: Location): Float {
+        val results = FloatArray(1)
+        Location.distanceBetween(cafeteria.latitude, cafeteria.longitude,
+                location.latitude, location.longitude, results)
+        return results[0]
+    }
+
+}


### PR DESCRIPTION
This PR refactors `CafeteriaActivity` and `CafeteriaViewModel` to be more reactive and extensible. It contains the following changes: 
1. Use `LiveData` to react to database queries and user interaction.
2. Move download of cafeteria information to `CafeteriaLocalRepository`, so that we don’t have to use a ViewModel in `DownloadService.`