### PR TITLE
Prevent crash when Intent can’t be handled

### DIFF
--- a/app/src/main/java/de/tum/in/tumcampusapp/component/tumui/person/PersonContactItemsAdapter.kt
+++ b/app/src/main/java/de/tum/in/tumcampusapp/component/tumui/person/PersonContactItemsAdapter.kt
@@ -1,13 +1,16 @@
 package de.tum.`in`.tumcampusapp.component.tumui.person
 
-import androidx.recyclerview.widget.RecyclerView
+import android.content.Context
+import android.content.Intent
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.recyclerview.widget.RecyclerView
 import de.tum.`in`.tumcampusapp.R
 import de.tum.`in`.tumcampusapp.component.tumui.person.adapteritems.AbstractContactItem
 import de.tum.`in`.tumcampusapp.component.tumui.person.adapteritems.MobilePhoneContactItem
 import de.tum.`in`.tumcampusapp.component.tumui.person.adapteritems.PhoneContactItem
+import de.tum.`in`.tumcampusapp.utils.Utils
 import kotlinx.android.synthetic.main.person_contact_item.view.*
 
 class PersonContactItemsAdapter(
@@ -49,8 +52,16 @@ class PersonContactItemsAdapter(
             valueTextView.text = item.value
 
             setOnClickListener {
-                val intent = item.getIntent(context) ?: return@setOnClickListener
+                item.getIntent(context)?.let { intent -> handleItemClick(context, intent) }
+            }
+        }
+
+        private fun handleItemClick(context: Context, intent: Intent) {
+            val canHandleIntent = intent.resolveActivity(context.packageManager) != null
+            if (canHandleIntent) {
                 context.startActivity(intent)
+            } else {
+                Utils.showToast(context, R.string.action_cant_be_performed)
             }
         }
 

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -657,4 +657,5 @@ Signatur: %5$s</string>
 
     <string name="update_note_title">Neue Features</string>
     <string name="update_note_version">Version %s</string>
+    <string name="action_cant_be_performed">Aktion kann nicht ausgeführt werden</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -711,4 +711,5 @@ Signature: %5$s</string>
     <string name="tickets_available_here">Tickets available here!</string>
     <string name="update_note_title">New Features</string>
     <string name="update_note_version">Version %s</string>
+    <string name="action_cant_be_performed">Action can’t be performed</string>
 </resources>


### PR DESCRIPTION
We had a crash because an `Intent` could not be handled. This commit fixes this (admittedly very minor) issue. 