### PR TITLE
Hide cards if no content is available

### DIFF
--- a/app/src/main/java/de/tum/in/tumcampusapp/component/ui/cafeteria/controller/CafeteriaManager.java
+++ b/app/src/main/java/de/tum/in/tumcampusapp/component/ui/cafeteria/controller/CafeteriaManager.java
@@ -43,7 +43,7 @@ public class CafeteriaManager implements ProvidesCard, ProvidesNotifications {
         List<Card> results = new ArrayList<>();
 
         CafeteriaWithMenus cafeteria = getCafeteriaWithMenus();
-        if (cafeteria == null) {
+        if (cafeteria == null || cafeteria.getMenus().isEmpty()) {
             return results;
         }
 

--- a/app/src/main/java/de/tum/in/tumcampusapp/component/ui/transportation/TransportController.kt
+++ b/app/src/main/java/de/tum/in/tumcampusapp/component/ui/transportation/TransportController.kt
@@ -117,6 +117,10 @@ class TransportController(private val context: Context) : ProvidesCard, Provides
         val station = locMan.getStation() ?: return emptyList()
 
         val departures = getDeparturesFromExternal(context, station.id).blockingFirst()
+        if (departures.isEmpty()) {
+            return emptyList()
+        }
+
         val card = MVVCard(context).apply {
             setStation(station)
             setDepartures(departures)


### PR DESCRIPTION
This commit fixes an issue where cards would be displayed even if they had no content to display. Examples: 
- `CafeteriaMenuCard` was displayed even if no menus were available for the current date.
- `MVVCard` was displayed even if no departures were found.