### PR TITLE
Show notifications for new grades

### DIFF
--- a/app/src/main/java/de/tum/in/tumcampusapp/component/notifications/persistence/NotificationType.kt
+++ b/app/src/main/java/de/tum/in/tumcampusapp/component/notifications/persistence/NotificationType.kt
@@ -6,7 +6,8 @@ enum class NotificationType(val id: Int) {
     CALENDAR(1),
     NEWS(2),
     TRANSPORT(3),
-    TUITION_FEES(4);
+    TUITION_FEES(4),
+    GRADES(5);
 
     companion object {
         private val map = NotificationType.values().associateBy(NotificationType::id)

--- a/app/src/main/java/de/tum/in/tumcampusapp/component/tumui/grades/GradesActivity.kt
+++ b/app/src/main/java/de/tum/in/tumcampusapp/component/tumui/grades/GradesActivity.kt
@@ -92,7 +92,7 @@ class GradesActivity : ActivityForAccessingTumOnline<ExamList>(R.layout.activity
     private fun storeGradedCourses(exams: List<Exam>) {
         val gradesStore = GradesStore(defaultSharedPreferences)
         val courses = exams.map { it.course }
-        gradesStore.storeGradedCourses(courses)
+        gradesStore.store(courses)
     }
 
     /**

--- a/app/src/main/java/de/tum/in/tumcampusapp/component/tumui/grades/GradesActivity.kt
+++ b/app/src/main/java/de/tum/in/tumcampusapp/component/tumui/grades/GradesActivity.kt
@@ -3,6 +3,8 @@ package de.tum.`in`.tumcampusapp.component.tumui.grades
 import android.animation.Animator
 import android.animation.AnimatorListenerAdapter
 import android.animation.LayoutTransition
+import android.content.Context
+import android.content.Intent
 import android.graphics.drawable.Animatable
 import android.os.Bundle
 import android.util.ArrayMap
@@ -20,6 +22,7 @@ import de.tum.`in`.tumcampusapp.component.other.generic.activity.ActivityForAcce
 import de.tum.`in`.tumcampusapp.component.tumui.grades.model.Exam
 import de.tum.`in`.tumcampusapp.component.tumui.grades.model.ExamList
 import kotlinx.android.synthetic.main.activity_grades.*
+import org.jetbrains.anko.defaultSharedPreferences
 import java.text.NumberFormat
 import java.util.*
 
@@ -82,6 +85,14 @@ class GradesActivity : ActivityForAccessingTumOnline<ExamList>(R.layout.activity
 
         isFetched = true
         invalidateOptionsMenu()
+
+        storeGradedCourses(response.exams)
+    }
+
+    private fun storeGradedCourses(exams: List<Exam>) {
+        val gradesStore = GradesStore(defaultSharedPreferences)
+        val courses = exams.map { it.course }
+        gradesStore.storeGradedCourses(courses)
     }
 
     /**
@@ -382,6 +393,8 @@ class GradesActivity : ActivityForAccessingTumOnline<ExamList>(R.layout.activity
     companion object {
         private const val KEY_SHOW_BAR_CHART = "showPieChart"
         private const val KEY_SPINNER_POSITION = "spinnerPosition"
+
+        fun newIntent(context: Context) = Intent(context, GradesActivity::class.java)
 
         private val GRADE_COLORS = intArrayOf(
                 R.color.grade_1_0, R.color.grade_1_3, R.color.grade_1_4, R.color.grade_1_7,

--- a/app/src/main/java/de/tum/in/tumcampusapp/component/tumui/grades/GradesBackgroundUpdater.kt
+++ b/app/src/main/java/de/tum/in/tumcampusapp/component/tumui/grades/GradesBackgroundUpdater.kt
@@ -36,7 +36,6 @@ class GradesBackgroundUpdater @Inject constructor(
 
         val newGradedCourses = courses - state.existingGrades
         if (newGradedCourses.isNotEmpty()) {
-            gradesStore.storeGradedCourses(courses)
             showGradesNotification(newGradedCourses)
         }
     }

--- a/app/src/main/java/de/tum/in/tumcampusapp/component/tumui/grades/GradesBackgroundUpdater.kt
+++ b/app/src/main/java/de/tum/in/tumcampusapp/component/tumui/grades/GradesBackgroundUpdater.kt
@@ -1,0 +1,68 @@
+package de.tum.`in`.tumcampusapp.component.tumui.grades
+
+import android.content.Context
+import de.tum.`in`.tumcampusapp.api.tumonline.CacheControl
+import de.tum.`in`.tumcampusapp.api.tumonline.TUMOnlineClient
+import de.tum.`in`.tumcampusapp.component.notifications.NotificationScheduler
+import de.tum.`in`.tumcampusapp.component.tumui.grades.model.Exam
+import de.tum.`in`.tumcampusapp.component.tumui.grades.model.ExamList
+import de.tum.`in`.tumcampusapp.utils.Utils
+import org.joda.time.DateTime
+import retrofit2.Call
+import retrofit2.Callback
+import retrofit2.Response
+import javax.inject.Inject
+
+class GradesBackgroundUpdater @Inject constructor(
+        private val context: Context,
+        private val tumOnlineClient: TUMOnlineClient,
+        private val notificationScheduler: NotificationScheduler,
+        private val gradesStore: GradesStore
+) : Callback<ExamList> {
+
+    fun fetchGradesAndNotifyIfNew(forceReload: Boolean) {
+        val cacheControl = if (forceReload) CacheControl.BYPASS_CACHE else CacheControl.USE_CACHE
+        tumOnlineClient.getGrades(cacheControl).enqueue(this)
+    }
+
+    override fun onResponse(call: Call<ExamList>, response: Response<ExamList>) {
+        val exams = response.body()?.exams.orEmpty()
+        val courses = exams.map { it.course }
+        val onlyOldExams = isLikelyOldExams(exams)
+
+        if (onlyOldExams) {
+            return
+        }
+
+        val existingCourses = gradesStore.getGradedCourses()
+        val newGradedCourses = existingCourses - courses
+
+        if (newGradedCourses.isNotEmpty()) {
+            showGradesNotification(newGradedCourses)
+        }
+    }
+
+    private fun isLikelyOldExams(exams: List<Exam>): Boolean {
+        // The grade is of an exam that occurred more than 4 weeks ago. To not notify the user
+        // the first time that they use this feature, we don't show a notification in this case.
+        val newestExam = exams
+                .mapNotNull { it.date }
+                .max() ?: DateTime.now()
+        return newestExam.isBefore(EXAM_THRESHOLD)
+    }
+
+    private fun showGradesNotification(newGrades: List<String>) {
+        val provider = GradesNotificationProvider(context, newGrades)
+        val notification = provider.buildNotification() ?: return
+        notificationScheduler.schedule(notification)
+    }
+
+    override fun onFailure(call: Call<ExamList>, t: Throwable) {
+        Utils.log(t)
+    }
+
+    companion object {
+        private val EXAM_THRESHOLD = DateTime.now().minusWeeks(4)
+    }
+
+}

--- a/app/src/main/java/de/tum/in/tumcampusapp/component/tumui/grades/GradesBackgroundUpdater.kt
+++ b/app/src/main/java/de/tum/in/tumcampusapp/component/tumui/grades/GradesBackgroundUpdater.kt
@@ -24,7 +24,7 @@ class GradesBackgroundUpdater @Inject constructor(
 
     override fun onResponse(call: Call<ExamList>, response: Response<ExamList>) {
         val courses = response.body()?.exams.orEmpty().map { it.course }
-        val state = gradesStore.getGradedCourses()
+        val state = gradesStore.state
 
         if (state.isFirstRefresh) {
             // On the first refresh, we store all downloaded grades in the empty GradesStore. We

--- a/app/src/main/java/de/tum/in/tumcampusapp/component/tumui/grades/GradesNotificationProvider.kt
+++ b/app/src/main/java/de/tum/in/tumcampusapp/component/tumui/grades/GradesNotificationProvider.kt
@@ -1,0 +1,52 @@
+package de.tum.`in`.tumcampusapp.component.tumui.grades
+
+import android.app.PendingIntent
+import android.app.PendingIntent.FLAG_UPDATE_CURRENT
+import android.content.Context
+import androidx.core.app.NotificationCompat
+import de.tum.`in`.tumcampusapp.R
+import de.tum.`in`.tumcampusapp.component.notifications.NotificationProvider
+import de.tum.`in`.tumcampusapp.component.notifications.model.AppNotification
+import de.tum.`in`.tumcampusapp.component.notifications.model.InstantNotification
+import de.tum.`in`.tumcampusapp.component.notifications.persistence.NotificationType
+import de.tum.`in`.tumcampusapp.utils.Const
+
+class GradesNotificationProvider(
+        context: Context,
+        private val newGrades: List<String>
+) : NotificationProvider(context) {
+
+    override fun getNotificationBuilder(): NotificationCompat.Builder {
+        return NotificationCompat.Builder(context, Const.NOTIFICATION_CHANNEL_DEFAULT)
+                .setSmallIcon(R.drawable.ic_notification)
+                .setGroup(GROUP_KEY_GRADES)
+                .setColor(notificationColorAccent)
+    }
+
+    override fun buildNotification(): AppNotification? {
+        val title = context.getString(R.string.my_grades)
+        val size = newGrades.size
+        val formattedNewGrades = newGrades.joinToString()
+
+        val text = context.resources.getQuantityString(
+                R.plurals.new_grades_format_string, size, size, formattedNewGrades)
+
+        val intent = GradesActivity.newIntent(context)
+        val pendingIntent = PendingIntent.getActivity(context, 0, intent, FLAG_UPDATE_CURRENT)
+
+        val notification = getNotificationBuilder()
+                .setContentTitle(title)
+                .setContentText(text)
+                .setContentIntent(pendingIntent)
+                .build()
+
+        // We can pass 0 as the notification ID because only one notification at a time
+        // will be active
+        return InstantNotification(NotificationType.GRADES, 0, notification)
+    }
+
+    companion object {
+        private const val GROUP_KEY_GRADES = "de.tum.in.tumcampus.GRADES"
+    }
+
+}

--- a/app/src/main/java/de/tum/in/tumcampusapp/component/tumui/grades/GradesStore.kt
+++ b/app/src/main/java/de/tum/in/tumcampusapp/component/tumui/grades/GradesStore.kt
@@ -18,9 +18,8 @@ class GradesStore @Inject constructor(
     private val gradedCourseNames: List<String>
         get() = sharedPrefs.getStringSet(KEY_GRADED_COURSES, emptySet()).toList()
 
-    fun getGradedCourses(): GradesStoreState {
-        return GradesStoreState(isFirstRefresh, gradedCourseNames)
-    }
+    val state: GradesStoreState
+        get() = GradesStoreState(isFirstRefresh, gradedCourseNames)
 
     fun storeGradedCourses(courses: List<String>) {
         sharedPrefs.edit().putStringSet(KEY_GRADED_COURSES, courses.toSet()).apply()

--- a/app/src/main/java/de/tum/in/tumcampusapp/component/tumui/grades/GradesStore.kt
+++ b/app/src/main/java/de/tum/in/tumcampusapp/component/tumui/grades/GradesStore.kt
@@ -3,12 +3,23 @@ package de.tum.`in`.tumcampusapp.component.tumui.grades
 import android.content.SharedPreferences
 import javax.inject.Inject
 
+data class GradesStoreState(
+        val isFirstRefresh: Boolean,
+        val existingGrades: List<String>
+)
+
 class GradesStore @Inject constructor(
         private val sharedPrefs: SharedPreferences
 ) {
 
-    fun getGradedCourses(): List<String> {
-        return sharedPrefs.getStringSet(KEY_GRADED_COURSES, emptySet()).toList()
+    private val isFirstRefresh: Boolean
+        get() = sharedPrefs.contains(KEY_GRADED_COURSES).not()
+
+    private val gradedCourseNames: List<String>
+        get() = sharedPrefs.getStringSet(KEY_GRADED_COURSES, emptySet()).toList()
+
+    fun getGradedCourses(): GradesStoreState {
+        return GradesStoreState(isFirstRefresh, gradedCourseNames)
     }
 
     fun storeGradedCourses(courses: List<String>) {

--- a/app/src/main/java/de/tum/in/tumcampusapp/component/tumui/grades/GradesStore.kt
+++ b/app/src/main/java/de/tum/in/tumcampusapp/component/tumui/grades/GradesStore.kt
@@ -1,0 +1,22 @@
+package de.tum.`in`.tumcampusapp.component.tumui.grades
+
+import android.content.SharedPreferences
+import javax.inject.Inject
+
+class GradesStore @Inject constructor(
+        private val sharedPrefs: SharedPreferences
+) {
+
+    fun getGradedCourses(): List<String> {
+        return sharedPrefs.getStringSet(KEY_GRADED_COURSES, emptySet()).toList()
+    }
+
+    fun storeGradedCourses(courses: List<String>) {
+        sharedPrefs.edit().putStringSet(KEY_GRADED_COURSES, courses.toSet()).apply()
+    }
+
+    companion object {
+        private const val KEY_GRADED_COURSES = "KEY_GRADED_COURSES"
+    }
+
+}

--- a/app/src/main/java/de/tum/in/tumcampusapp/component/tumui/grades/GradesStore.kt
+++ b/app/src/main/java/de/tum/in/tumcampusapp/component/tumui/grades/GradesStore.kt
@@ -3,25 +3,14 @@ package de.tum.`in`.tumcampusapp.component.tumui.grades
 import android.content.SharedPreferences
 import javax.inject.Inject
 
-data class GradesStoreState(
-        val isFirstRefresh: Boolean,
-        val existingGrades: List<String>
-)
-
 class GradesStore @Inject constructor(
         private val sharedPrefs: SharedPreferences
 ) {
 
-    private val isFirstRefresh: Boolean
-        get() = sharedPrefs.contains(KEY_GRADED_COURSES).not()
+    val gradedCourses: List<String>
+        get() = sharedPrefs.getStringSet(KEY_GRADED_COURSES, emptySet()).toList().sorted()
 
-    private val gradedCourseNames: List<String>
-        get() = sharedPrefs.getStringSet(KEY_GRADED_COURSES, emptySet()).toList()
-
-    val state: GradesStoreState
-        get() = GradesStoreState(isFirstRefresh, gradedCourseNames)
-
-    fun storeGradedCourses(courses: List<String>) {
+    fun store(courses: List<String>) {
         sharedPrefs.edit().putStringSet(KEY_GRADED_COURSES, courses.toSet()).apply()
     }
 

--- a/app/src/main/java/de/tum/in/tumcampusapp/di/AppModule.kt
+++ b/app/src/main/java/de/tum/in/tumcampusapp/di/AppModule.kt
@@ -8,6 +8,7 @@ import dagger.Provides
 import de.tum.`in`.tumcampusapp.api.app.AuthenticationManager
 import de.tum.`in`.tumcampusapp.api.app.TUMCabeClient
 import de.tum.`in`.tumcampusapp.api.tumonline.TUMOnlineClient
+import de.tum.`in`.tumcampusapp.component.notifications.NotificationScheduler
 import de.tum.`in`.tumcampusapp.component.other.locations.LocationManager
 import de.tum.`in`.tumcampusapp.component.ui.news.RealTopNewsStore
 import de.tum.`in`.tumcampusapp.component.ui.news.TopNewsStore
@@ -91,5 +92,11 @@ class AppModule(private val context: Context) {
     fun provideAuthenticationManager(
             context: Context
     ): AuthenticationManager = AuthenticationManager(context)
+
+    @Singleton
+    @Provides
+    fun provideNotificationScheduler(
+            context: Context
+    ): NotificationScheduler = NotificationScheduler(context)
 
 }

--- a/app/src/main/java/de/tum/in/tumcampusapp/service/DownloadService.kt
+++ b/app/src/main/java/de/tum/in/tumcampusapp/service/DownloadService.kt
@@ -184,7 +184,7 @@ class DownloadService : JobIntentService() {
     }
 
     private fun downloadGrades(): Boolean {
-        gradesBackgroundUpdater.fetchGradesAndNotifyIfNew(true)
+        gradesBackgroundUpdater.fetchGradesAndNotifyIfNecessary()
         return true
     }
 

--- a/app/src/main/java/de/tum/in/tumcampusapp/service/DownloadService.kt
+++ b/app/src/main/java/de/tum/in/tumcampusapp/service/DownloadService.kt
@@ -9,6 +9,7 @@ import de.tum.`in`.tumcampusapp.api.app.AuthenticationManager
 import de.tum.`in`.tumcampusapp.api.app.TUMCabeClient
 import de.tum.`in`.tumcampusapp.api.app.model.UploadStatus
 import de.tum.`in`.tumcampusapp.api.tumonline.AccessTokenManager
+import de.tum.`in`.tumcampusapp.component.tumui.grades.GradesBackgroundUpdater
 import de.tum.`in`.tumcampusapp.component.ui.cafeteria.controller.CafeteriaMenuManager
 import de.tum.`in`.tumcampusapp.component.ui.cafeteria.model.Location
 import de.tum.`in`.tumcampusapp.component.ui.cafeteria.repository.CafeteriaRemoteRepository
@@ -64,6 +65,9 @@ class DownloadService : JobIntentService() {
     @Inject
     lateinit var cafeteriaMenuManager: CafeteriaMenuManager
 
+    @Inject
+    lateinit var gradesBackgroundUpdater: GradesBackgroundUpdater
+
     private val disposable = CompositeDisposable()
 
     override fun onCreate() {
@@ -111,7 +115,9 @@ class DownloadService : JobIntentService() {
         val newsSuccess = downloadNews(force)
         val eventsSuccess = downloadEvents()
         val topNewsSuccess = downloadTopNews()
-        return updateNoteSuccess && cafeSuccess && kinoSuccess && newsSuccess && topNewsSuccess && eventsSuccess
+        val gradesSuccess = downloadGrades()
+        return updateNoteSuccess && cafeSuccess && kinoSuccess
+                && newsSuccess && topNewsSuccess && eventsSuccess && gradesSuccess
     }
 
     /**
@@ -174,6 +180,11 @@ class DownloadService : JobIntentService() {
 
     private fun downloadTopNews(): Boolean {
         topNewsRemoteRepository.fetchNewsAlert()
+        return true
+    }
+
+    private fun downloadGrades(): Boolean {
+        gradesBackgroundUpdater.fetchGradesAndNotifyIfNew(true)
         return true
     }
 

--- a/app/src/main/java/de/tum/in/tumcampusapp/service/di/DownloadModule.kt
+++ b/app/src/main/java/de/tum/in/tumcampusapp/service/di/DownloadModule.kt
@@ -1,9 +1,14 @@
 package de.tum.`in`.tumcampusapp.service.di
 
 import android.content.Context
+import android.content.SharedPreferences
 import dagger.Module
 import dagger.Provides
 import de.tum.`in`.tumcampusapp.api.app.TUMCabeClient
+import de.tum.`in`.tumcampusapp.api.tumonline.TUMOnlineClient
+import de.tum.`in`.tumcampusapp.component.notifications.NotificationScheduler
+import de.tum.`in`.tumcampusapp.component.tumui.grades.GradesBackgroundUpdater
+import de.tum.`in`.tumcampusapp.component.tumui.grades.GradesStore
 import de.tum.`in`.tumcampusapp.component.ui.cafeteria.controller.CafeteriaMenuManager
 import de.tum.`in`.tumcampusapp.component.ui.cafeteria.repository.CafeteriaLocalRepository
 import de.tum.`in`.tumcampusapp.component.ui.news.NewsController
@@ -51,5 +56,23 @@ class DownloadModule {
     fun provideCafeteriaMenuManager(
             context: Context
     ): CafeteriaMenuManager = CafeteriaMenuManager(context)
+
+    @Provides
+    fun provideGradesStore(
+            sharedPrefs: SharedPreferences
+    ): GradesStore = GradesStore(sharedPrefs)
+
+    @Provides
+    fun provideGradesBackgroundUpdater(
+            context: Context,
+            tumOnlineClient: TUMOnlineClient,
+            notificationScheduler: NotificationScheduler,
+            gradesStore: GradesStore
+    ): GradesBackgroundUpdater = GradesBackgroundUpdater(
+            context,
+            tumOnlineClient,
+            notificationScheduler,
+            gradesStore
+    )
 
 }

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -658,4 +658,9 @@ Signatur: %5$s</string>
     <string name="update_note_title">Neue Features</string>
     <string name="update_note_version">Version %s</string>
     <string name="action_cant_be_performed">Aktion kann nicht ausgeführt werden</string>
+
+    <plurals name="new_grades_format_string">
+        <item quantity="one">%d neue Note verfügbar</item>
+        <item quantity="other">%d neue Noten verfügbar</item>
+    </plurals>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -712,4 +712,9 @@ Signature: %5$s</string>
     <string name="update_note_title">New Features</string>
     <string name="update_note_version">Version %s</string>
     <string name="action_cant_be_performed">Action can’t be performed</string>
+
+    <plurals name="new_grades_format_string">
+        <item quantity="one">%d new grade available %s</item>
+        <item quantity="other">%d new grades available: %s</item>
+    </plurals>
 </resources>


### PR DESCRIPTION
This pull request implements notifications for new grades, as specified in #688. Whenever `DownloadService` is run, `GradesBackgroundUpdater` fetches the user’s grades and compares them with existing grades in `GradesStore`. If any new grades have been added, we display a notification via `GradesNotificationProvider`.