### PR TITLE
Fix issue where dismissed TopNewsCard would appear again

### DIFF
--- a/app/src/main/java/de/tum/in/tumcampusapp/component/ui/news/TopNewsStore.kt
+++ b/app/src/main/java/de/tum/in/tumcampusapp/component/ui/news/TopNewsStore.kt
@@ -53,7 +53,7 @@ class RealTopNewsStore @Inject constructor(
     }
 
     override fun setEnabled(isEnabled: Boolean) {
-        sharedPrefs.edit().putBoolean(CardManager.SHOW_TOP_NEWS, true).apply()
+        sharedPrefs.edit().putBoolean(CardManager.SHOW_TOP_NEWS, isEnabled).apply()
     }
 
     override fun getNewsAlert(): NewsAlert? {


### PR DESCRIPTION
This commit fixes an issue where the `TopNewsCard` was displayed even if the user had previously dismissed it.