### PR TITLE
Fix crash in BuyTicketActivity

### DIFF
--- a/app/src/main/java/de/tum/in/tumcampusapp/component/ui/ticket/activity/BuyTicketActivity.java
+++ b/app/src/main/java/de/tum/in/tumcampusapp/component/ui/ticket/activity/BuyTicketActivity.java
@@ -24,7 +24,6 @@ import de.tum.in.tumcampusapp.api.app.model.TUMCabeVerification;
 import de.tum.in.tumcampusapp.component.other.generic.activity.BaseActivity;
 import de.tum.in.tumcampusapp.component.ui.ticket.di.TicketsModule;
 import de.tum.in.tumcampusapp.component.ui.ticket.model.Event;
-import de.tum.in.tumcampusapp.component.ui.ticket.model.EventType;
 import de.tum.in.tumcampusapp.component.ui.ticket.model.TicketType;
 import de.tum.in.tumcampusapp.component.ui.ticket.payload.TicketReservation;
 import de.tum.in.tumcampusapp.component.ui.ticket.payload.TicketReservationResponse;
@@ -72,9 +71,8 @@ public class BuyTicketActivity extends BaseActivity {
         eventId = getIntent().getIntExtra(Const.KEY_EVENT_ID, 0);
 
         getInjector().ticketsComponent()
-                .ticketsModule(new TicketsModule(this))
+                .ticketsModule(new TicketsModule())
                 .eventId(eventId)
-                .eventType(EventType.ALL) // not important here
                 .build()
                 .inject(this);
 

--- a/app/src/main/java/de/tum/in/tumcampusapp/component/ui/ticket/activity/BuyTicketActivity.java
+++ b/app/src/main/java/de/tum/in/tumcampusapp/component/ui/ticket/activity/BuyTicketActivity.java
@@ -24,6 +24,7 @@ import de.tum.in.tumcampusapp.api.app.model.TUMCabeVerification;
 import de.tum.in.tumcampusapp.component.other.generic.activity.BaseActivity;
 import de.tum.in.tumcampusapp.component.ui.ticket.di.TicketsModule;
 import de.tum.in.tumcampusapp.component.ui.ticket.model.Event;
+import de.tum.in.tumcampusapp.component.ui.ticket.model.EventType;
 import de.tum.in.tumcampusapp.component.ui.ticket.model.TicketType;
 import de.tum.in.tumcampusapp.component.ui.ticket.payload.TicketReservation;
 import de.tum.in.tumcampusapp.component.ui.ticket.payload.TicketReservationResponse;
@@ -73,9 +74,9 @@ public class BuyTicketActivity extends BaseActivity {
         getInjector().ticketsComponent()
                 .ticketsModule(new TicketsModule(this))
                 .eventId(eventId)
+                .eventType(EventType.ALL) // not important here
                 .build()
                 .inject(this);
-
 
         // Get ticket type information from API
         Disposable disposable = ticketsRemoteRepo.fetchTicketTypesForEvent(eventId)

--- a/app/src/main/java/de/tum/in/tumcampusapp/component/ui/ticket/activity/ShowTicketActivity.java
+++ b/app/src/main/java/de/tum/in/tumcampusapp/component/ui/ticket/activity/ShowTicketActivity.java
@@ -72,7 +72,7 @@ public class ShowTicketActivity extends BaseActivity {
 
         int eventId = getIntent().getIntExtra(Const.KEY_EVENT_ID, 0);
         getInjector().ticketsComponent()
-                .ticketsModule(new TicketsModule(this))
+                .ticketsModule(new TicketsModule())
                 .eventId(eventId)
                 .build()
                 .inject(this);

--- a/app/src/main/java/de/tum/in/tumcampusapp/component/ui/ticket/di/EventsComponent.kt
+++ b/app/src/main/java/de/tum/in/tumcampusapp/component/ui/ticket/di/EventsComponent.kt
@@ -1,0 +1,25 @@
+package de.tum.`in`.tumcampusapp.component.ui.ticket.di
+
+import dagger.BindsInstance
+import dagger.Subcomponent
+import de.tum.`in`.tumcampusapp.component.ui.ticket.fragment.EventsFragment
+import de.tum.`in`.tumcampusapp.component.ui.ticket.model.EventType
+
+@Subcomponent(modules = [EventsModule::class])
+interface EventsComponent {
+
+    fun inject(eventsFragment: EventsFragment)
+
+    @Subcomponent.Builder
+    interface Builder {
+
+        fun eventsModule(eventsModule: EventsModule): EventsComponent.Builder
+
+        @BindsInstance
+        fun eventType(eventType: EventType): EventsComponent.Builder
+
+        fun build(): EventsComponent
+
+    }
+
+}

--- a/app/src/main/java/de/tum/in/tumcampusapp/component/ui/ticket/di/EventsModule.kt
+++ b/app/src/main/java/de/tum/in/tumcampusapp/component/ui/ticket/di/EventsModule.kt
@@ -11,7 +11,7 @@ import de.tum.`in`.tumcampusapp.component.ui.ticket.repository.TicketsRemoteRepo
 import de.tum.`in`.tumcampusapp.database.TcaDb
 
 @Module
-class TicketsModule {
+class EventsModule {
 
     @Provides
     fun provideTicketsLocalRepository(

--- a/app/src/main/java/de/tum/in/tumcampusapp/component/ui/ticket/di/TicketsComponent.kt
+++ b/app/src/main/java/de/tum/in/tumcampusapp/component/ui/ticket/di/TicketsComponent.kt
@@ -6,13 +6,9 @@ import de.tum.`in`.tumcampusapp.component.ui.ticket.activity.BuyTicketActivity
 import de.tum.`in`.tumcampusapp.component.ui.ticket.activity.ShowTicketActivity
 import de.tum.`in`.tumcampusapp.component.ui.ticket.activity.StripePaymentActivity
 import de.tum.`in`.tumcampusapp.component.ui.ticket.fragment.EventDetailsFragment
-import de.tum.`in`.tumcampusapp.component.ui.ticket.fragment.EventsFragment
-import de.tum.`in`.tumcampusapp.component.ui.ticket.model.EventType
 
 @Subcomponent(modules = [TicketsModule::class])
 interface TicketsComponent {
-
-    fun inject(eventsFragment: EventsFragment)
 
     fun inject(eventDetailsFragment: EventDetailsFragment)
 
@@ -26,9 +22,6 @@ interface TicketsComponent {
     interface Builder {
 
         fun ticketsModule(ticketsModule: TicketsModule): TicketsComponent.Builder
-
-        @BindsInstance
-        fun eventType(eventType: EventType): TicketsComponent.Builder
 
         @BindsInstance
         fun eventId(@EventId eventId: Int): TicketsComponent.Builder

--- a/app/src/main/java/de/tum/in/tumcampusapp/component/ui/ticket/fragment/EventDetailsFragment.kt
+++ b/app/src/main/java/de/tum/in/tumcampusapp/component/ui/ticket/fragment/EventDetailsFragment.kt
@@ -53,7 +53,7 @@ class EventDetailsFragment : Fragment(), SwipeRefreshLayout.OnRefreshListener {
     override fun onAttach(context: Context?) {
         super.onAttach(context)
         injector.ticketsComponent()
-                .ticketsModule(TicketsModule(requireContext()))
+                .ticketsModule(TicketsModule())
                 .eventId(event.id)
                 .build()
                 .inject(this)

--- a/app/src/main/java/de/tum/in/tumcampusapp/component/ui/ticket/fragment/EventsFragment.kt
+++ b/app/src/main/java/de/tum/in/tumcampusapp/component/ui/ticket/fragment/EventsFragment.kt
@@ -16,7 +16,7 @@ import de.tum.`in`.tumcampusapp.component.ui.chat.model.ChatMember
 import de.tum.`in`.tumcampusapp.component.ui.ticket.EventsViewModel
 import de.tum.`in`.tumcampusapp.component.ui.ticket.EventsViewState
 import de.tum.`in`.tumcampusapp.component.ui.ticket.adapter.EventsAdapter
-import de.tum.`in`.tumcampusapp.component.ui.ticket.di.TicketsModule
+import de.tum.`in`.tumcampusapp.component.ui.ticket.di.EventsModule
 import de.tum.`in`.tumcampusapp.component.ui.ticket.model.EventType
 import de.tum.`in`.tumcampusapp.di.ViewModelFactory
 import de.tum.`in`.tumcampusapp.di.injector
@@ -43,10 +43,9 @@ class EventsFragment : Fragment(), SwipeRefreshLayout.OnRefreshListener {
 
     override fun onAttach(context: Context?) {
         super.onAttach(context)
-        injector.ticketsComponent()
-                .ticketsModule(TicketsModule(requireContext()))
+        injector.eventsComponent()
+                .eventsModule(EventsModule())
                 .eventType(eventType)
-                .eventId(0) // not relevant here
                 .build()
                 .inject(this)
     }

--- a/app/src/main/java/de/tum/in/tumcampusapp/di/AppComponent.kt
+++ b/app/src/main/java/de/tum/in/tumcampusapp/di/AppComponent.kt
@@ -3,6 +3,7 @@ package de.tum.`in`.tumcampusapp.di
 import dagger.Component
 import de.tum.`in`.tumcampusapp.component.ui.cafeteria.di.CafeteriaComponent
 import de.tum.`in`.tumcampusapp.component.ui.overview.MainActivity
+import de.tum.`in`.tumcampusapp.component.ui.ticket.di.EventsComponent
 import de.tum.`in`.tumcampusapp.component.ui.ticket.di.TicketsComponent
 import de.tum.`in`.tumcampusapp.component.ui.tufilm.di.KinoComponent
 import de.tum.`in`.tumcampusapp.service.di.DownloadComponent
@@ -15,6 +16,8 @@ interface AppComponent {
     fun cafeteriaComponent(): CafeteriaComponent.Builder
 
     fun downloadComponent(): DownloadComponent.Builder
+
+    fun eventsComponent(): EventsComponent.Builder
 
     fun kinoComponent(): KinoComponent.Builder
 


### PR DESCRIPTION
This commit fixes the crash in `BuyTicketActivity` (#1250) ~via a short workaround. I will refactor the Dagger components for the event and ticket screens, so that we don’t have to do this sort of thing again in the future~ by refactoring the `TicketsComponent` and breaking out a new `EventsComponent`.