### PR TITLE
Prevent grade download attempt without token

### DIFF
--- a/app/src/main/java/de/tum/in/tumcampusapp/service/DownloadService.kt
+++ b/app/src/main/java/de/tum/in/tumcampusapp/service/DownloadService.kt
@@ -115,9 +115,8 @@ class DownloadService : JobIntentService() {
         val newsSuccess = downloadNews(force)
         val eventsSuccess = downloadEvents()
         val topNewsSuccess = downloadTopNews()
-        val gradesSuccess = downloadGrades()
         return updateNoteSuccess && cafeSuccess && kinoSuccess
-                && newsSuccess && topNewsSuccess && eventsSuccess && gradesSuccess
+                && newsSuccess && topNewsSuccess && eventsSuccess
     }
 
     /**
@@ -255,6 +254,7 @@ class DownloadService : JobIntentService() {
                         if (AccessTokenManager.hasValidAccessToken(service)) {
                             val cacheManager = CacheManager(service)
                             cacheManager.fillCache()
+                            success = success && service.downloadGrades()
                         }
                     }
                 }


### PR DESCRIPTION
## Issue
Fixes #1254 

I the only requests that were sent without checking were for the grades.
I haven't seen any other exceptions or code that suggested otherwise.