### PR TITLE
Hide buy button and number of remaining tickets if no tickets available

### DIFF
--- a/app/src/main/java/de/tum/in/tumcampusapp/component/ui/ticket/fragment/EventDetailsFragment.kt
+++ b/app/src/main/java/de/tum/in/tumcampusapp/component/ui/ticket/fragment/EventDetailsFragment.kt
@@ -95,6 +95,7 @@ class EventDetailsFragment : Fragment(), SwipeRefreshLayout.OnRefreshListener {
 
         if (viewModel.isEventBooked(event)) {
             ticketButton.text = getString(R.string.show_ticket)
+            ticketButton.text = resources.getQuantityText(R.plurals.show_tickets, viewModel.getNumEventsBooked(event))
             ticketButton.setOnClickListener { showTicket(event) }
         } else {
             ticketButton.text = getString(R.string.buy_ticket)

--- a/app/src/main/java/de/tum/in/tumcampusapp/component/ui/ticket/fragment/EventDetailsFragment.kt
+++ b/app/src/main/java/de/tum/in/tumcampusapp/component/ui/ticket/fragment/EventDetailsFragment.kt
@@ -21,11 +21,8 @@ import de.tum.`in`.tumcampusapp.component.ui.ticket.di.TicketsModule
 import de.tum.`in`.tumcampusapp.component.ui.ticket.model.Event
 import de.tum.`in`.tumcampusapp.di.ViewModelFactory
 import de.tum.`in`.tumcampusapp.di.injector
-import de.tum.`in`.tumcampusapp.utils.Const
+import de.tum.`in`.tumcampusapp.utils.*
 import de.tum.`in`.tumcampusapp.utils.Const.KEY_EVENT_ID
-import de.tum.`in`.tumcampusapp.utils.DateTimeUtils
-import de.tum.`in`.tumcampusapp.utils.into
-import de.tum.`in`.tumcampusapp.utils.observe
 import kotlinx.android.synthetic.main.fragment_event_details.*
 import kotlinx.android.synthetic.main.fragment_event_details.view.*
 import javax.inject.Inject
@@ -83,13 +80,6 @@ class EventDetailsFragment : Fragment(), SwipeRefreshLayout.OnRefreshListener {
         viewModel.fetchTicketCount()
     }
 
-    override fun onResume() {
-        super.onResume()
-        if (!viewModel.isEventBooked(event) && EventHelper.isEventImminent(event)) {
-            ticketButton.visibility = View.GONE
-        }
-    }
-
     private fun showEventDetails(event: Event) {
         val url = event.imageUrl
         if (url != null) {
@@ -131,8 +121,23 @@ class EventDetailsFragment : Fragment(), SwipeRefreshLayout.OnRefreshListener {
     }
 
     private fun showTicketCount(count: Int?) {
-        val text = count?.toString() ?: getString(R.string.unknown)
-        remainingTicketsTextView.text = text
+        if(EventHelper.isEventImminent(event)) {
+            ticketButton.visibility = if(!viewModel.isEventBooked(event)) View.GONE else View.VISIBLE
+            remainingTicketsContainer.visibility = View.GONE
+        } else {
+            if (count == null || count < 0) {
+                if(!viewModel.isEventBooked(event)) ticketButton.visibility = View.GONE
+                remainingTicketsContainer.visibility = View.GONE
+            } else if(count > 0) {
+                ticketButton.visibility = View.VISIBLE
+                remainingTicketsContainer.visibility = View.VISIBLE
+                remainingTicketsTextView.text = count.toString()
+            } else {
+                ticketButton.visibility = View.GONE
+                remainingTicketsContainer.visibility = View.VISIBLE
+                remainingTicketsTextView.text = getString(R.string.no_tickets_remaining_message)
+            }
+        }
         swipeRefreshLayout.isRefreshing = false
     }
 

--- a/app/src/main/java/de/tum/in/tumcampusapp/component/ui/ticket/fragment/EventDetailsFragment.kt
+++ b/app/src/main/java/de/tum/in/tumcampusapp/component/ui/ticket/fragment/EventDetailsFragment.kt
@@ -133,7 +133,7 @@ class EventDetailsFragment : Fragment(), SwipeRefreshLayout.OnRefreshListener {
                 remainingTicketsContainer.visibility = View.VISIBLE
                 remainingTicketsTextView.text = count.toString()
             } else {
-                ticketButton.visibility = View.GONE
+                ticketButton.visibility = if(!viewModel.isEventBooked(event)) View.GONE else View.VISIBLE
                 remainingTicketsContainer.visibility = View.VISIBLE
                 remainingTicketsTextView.text = getString(R.string.no_tickets_remaining_message)
             }

--- a/app/src/main/java/de/tum/in/tumcampusapp/component/ui/ticket/fragment/EventDetailsViewModel.kt
+++ b/app/src/main/java/de/tum/in/tumcampusapp/component/ui/ticket/fragment/EventDetailsViewModel.kt
@@ -37,7 +37,9 @@ class EventDetailsViewModel @Inject constructor(
                 }
     }
 
-    fun isEventBooked(event: Event): Boolean = ticketsLocalRepository.getTicketCount(event) != 0
+    fun isEventBooked(event: Event): Boolean = ticketsLocalRepository.getTicketCount(event) > 0
+
+    fun getNumEventsBooked(event: Event): Int = ticketsLocalRepository.getTicketCount(event)
 
     override fun onCleared() {
         super.onCleared()

--- a/app/src/main/java/de/tum/in/tumcampusapp/component/ui/tufilm/KinoDetailsFragment.java
+++ b/app/src/main/java/de/tum/in/tumcampusapp/component/ui/tufilm/KinoDetailsFragment.java
@@ -11,6 +11,7 @@ import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.ImageView;
+import android.widget.LinearLayout;
 import android.widget.ProgressBar;
 import android.widget.TextView;
 
@@ -19,6 +20,7 @@ import com.squareup.picasso.Picasso;
 import com.squareup.picasso.Target;
 
 import java.util.Locale;
+import java.util.Optional;
 
 import javax.inject.Inject;
 import javax.inject.Provider;
@@ -30,6 +32,7 @@ import androidx.fragment.app.Fragment;
 import androidx.lifecycle.ViewModelProviders;
 import de.tum.in.tumcampusapp.R;
 import de.tum.in.tumcampusapp.component.other.generic.activity.BaseActivity;
+import de.tum.in.tumcampusapp.component.tumui.feedback.FeedbackContract;
 import de.tum.in.tumcampusapp.component.ui.ticket.EventHelper;
 import de.tum.in.tumcampusapp.component.ui.ticket.activity.ShowTicketActivity;
 import de.tum.in.tumcampusapp.component.ui.ticket.model.Event;
@@ -116,9 +119,10 @@ public class KinoDetailsFragment extends Fragment {
 
     private void initBuyOrShowTicket(Event event) {
         MaterialButton ticketButton = rootView.findViewById(R.id.buyTicketButton);
-        if (ticketsLocalRepo.getTicketCount(event) != 0) {
-            ticketButton.setText(R.string.show_ticket);
-            ticketButton.setVisibility(View.VISIBLE);
+        int ticketBoughtCount = ticketsLocalRepo.getTicketCount(event);
+
+        if (ticketBoughtCount > 0) {
+            ticketButton.setText(getResources().getQuantityString(R.plurals.show_tickets, ticketBoughtCount));
             ticketButton.setOnClickListener(view -> {
                 Intent intent = new Intent(getContext(), ShowTicketActivity.class);
                 intent.putExtra(KEY_EVENT_ID, event.getId());
@@ -126,22 +130,38 @@ public class KinoDetailsFragment extends Fragment {
             });
         } else if (!EventHelper.Companion.isEventImminent(event)) {
             ticketButton.setText(R.string.buy_ticket);
-            ticketButton.setVisibility(View.VISIBLE);
             ticketButton.setOnClickListener(
                     view -> EventHelper.Companion.buyTicket(this.event, ticketButton, getContext()));
         }
     }
 
     private void showTicketCount(@Nullable Integer count) {
-        String text;
+        TextView remainingTicketsTextView = rootView.findViewById(R.id.remainingTicketsTextView);
+        TextView remainingTicketsHeaderView = rootView.findViewById(R.id.remainingTicketsHeaderTextView);
+        MaterialButton ticketButton = rootView.findViewById(R.id.buyTicketButton);
+        int ticketBoughtCount = ticketsLocalRepo.getTicketCount(event);
 
-        if (count != null) {
-            text = String.format(Locale.getDefault(), "%d", count);
+        if(EventHelper.Companion.isEventImminent(event)) {
+            ticketButton.setVisibility((ticketBoughtCount <= 0) ? View.GONE : View.VISIBLE);
+            remainingTicketsHeaderView.setVisibility(View.GONE);
+            remainingTicketsTextView.setVisibility(View.GONE);
         } else {
-            text = getString(R.string.unknown);
+            if (count == null || count < 0) {
+                ticketButton.setVisibility((ticketBoughtCount <= 0) ? View.GONE : View.VISIBLE);
+                remainingTicketsHeaderView.setVisibility(View.GONE);
+                remainingTicketsTextView.setVisibility(View.GONE);
+            } else if(count > 0) {
+                ticketButton.setVisibility(View.VISIBLE);
+                remainingTicketsHeaderView.setVisibility(View.VISIBLE);
+                remainingTicketsTextView.setText(String.format(Locale.getDefault(), "%d", count));
+                remainingTicketsTextView.setVisibility(View.VISIBLE);
+            } else {
+                ticketButton.setVisibility(View.GONE);
+                remainingTicketsHeaderView.setVisibility(View.VISIBLE);
+                remainingTicketsTextView.setText(R.string.no_tickets_remaining_tufilm_message);
+                remainingTicketsTextView.setVisibility(View.VISIBLE);
+            }
         }
-
-        ((TextView) rootView.findViewById(R.id.remainingTicketsTextView)).setText(text);
     }
 
     private void showMovieDetails(Kino kino) {
@@ -230,5 +250,4 @@ public class KinoDetailsFragment extends Fragment {
         Intent intent = new Intent(Intent.ACTION_VIEW, Uri.parse(url));
         requireActivity().startActivity(intent);
     }
-
 }

--- a/app/src/main/java/de/tum/in/tumcampusapp/component/ui/tufilm/KinoDetailsFragment.java
+++ b/app/src/main/java/de/tum/in/tumcampusapp/component/ui/tufilm/KinoDetailsFragment.java
@@ -156,7 +156,7 @@ public class KinoDetailsFragment extends Fragment {
                 remainingTicketsTextView.setText(String.format(Locale.getDefault(), "%d", count));
                 remainingTicketsTextView.setVisibility(View.VISIBLE);
             } else {
-                ticketButton.setVisibility(View.GONE);
+                ticketButton.setVisibility((ticketBoughtCount <= 0) ? View.GONE : View.VISIBLE);
                 remainingTicketsHeaderView.setVisibility(View.VISIBLE);
                 remainingTicketsTextView.setText(R.string.no_tickets_remaining_tufilm_message);
                 remainingTicketsTextView.setVisibility(View.VISIBLE);

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -109,6 +109,7 @@
     <string name="actors">Schauspieler</string>
     <string name="description">Beschreibung</string>
     <string name="no_movies">Keine Filme in nächster Zeit</string>
+    <string name="no_tickets_remaining_tufilm_message">Derzeit stehen leider keine weiteren Online Tickets für diesen Film zur Verfügung.\nWeitere Tickets können an der Abendkasse sowie den Vorverkaufsstellen erworben werden.</string>
 
     <!-- Navigation drawer -->
     <string name="drawer_open">Öffnen</string>
@@ -507,7 +508,7 @@ Signatur: %5$s</string>
     <string name="partially_redeemed">%d von %d eingelöst (%s)</string>
     <string name="redeemed_at">Eingelöst um %s</string>
     <string name="no_tickets_remaining">Keine Tickets mehr vorhanden</string>
-    <string name="no_tickets_remaining_message">Du warst leider zu spät dran und die Tickets sind hier bereits ausverkauft. Bei vielen Events kannst du aber noch Tickets an der Abendkasse erwerben.</string>
+    <string name="no_tickets_remaining_message">Leider stehen für diese Veranstaltung keine weiteren Online Tickets zur Verfügung.\nBei vielen Veranstaltungen kannst du aber vor Ort noch Tickets erwerben.</string>
     <string name="error_message_select_at_least_one_ticket">Bitte wähle mindestens ein Ticket aus einer der Kategorien aus.</string>
     <string name="error_no_ticket_selected">Keine Tickets ausgewählt</string>
     <string name="ticket_amount_information">Es können maximal %d Tickets pro Person vom Typ \“%s\” gekauft werden.</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -317,7 +317,7 @@
     <string name="closed">Closed</string>
 
     <!-- Kino -->
-    <string name="kino" translatable="false">tu film</string>
+    <string name="kino" translatable="false">der tu film</string>
     <string name="imdb_rating">IMDb-Rating</string>
     <string name="year">Year of release</string>
     <string name="runtime">Runtime</string>
@@ -435,7 +435,7 @@ Signature: %5$s</string>
     <string name="ok">OK</string>
     <string name="alarm_date_published_on">Published on:</string>
     <string name="chat_not_setup">Chat is not setup properly, please rerun the wizard via the settings!</string>
-    <string name="www" translatable="false">TU Film</string>
+    <string name="www" translatable="false">der tu film</string>
     <string name="more_info">More Information</string>
     <string name="event_plan">Event plan</string>
     <string name="please_connect_to_internet">Please connect to internet in order to proceed the first app start</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -325,8 +325,9 @@
     <string name="director">Director</string>
     <string name="actors">Actors</string>
     <string name="description">Description</string>
-
     <string name="no_movies">No upcoming movies</string>
+    <string name="no_tickets_remaining_tufilm_message">Unfortunately there are no more online tickets available for this movie.\nAdditional tickets can be purchased at our evening box office or our advance ticket sales desks.</string>
+
     <!-- Eduroam card -->
     <string name="eduroam" translatable="false">Eduroam</string>
     <string name="setup">Setup</string>
@@ -733,7 +734,7 @@ Signature: %5$s</string>
     <string name="partially_redeemed">%d of %d redeemed (%s)</string>
     <string name="redeemed_at">Redeemed at %s</string>
     <string name="no_tickets_remaining">No tickets remaining</string>
-    <string name="no_tickets_remaining_message">Unfortunately you were a little too late, there are not tickets available anymore. For many events you can still buy a ticket on site.</string>
+    <string name="no_tickets_remaining_message">Unfortunately there are no more online tickets available for this event.\nFor many events you can still purchase tickets on site.</string>
     <string name="error_message_select_at_least_one_ticket">Please select at least one ticket from one of the categories.</string>
     <string name="error_no_ticket_selected">No tickets selected</string>
     <string name="amount_x" translatable="false">%dx</string>

--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ buildscript {
         maven { url 'https://maven.fabric.io/public' }
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.3.2'
+        classpath 'com.android.tools.build:gradle:3.4.0'
         classpath 'com.google.gms:google-services:4.2.0'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath 'io.fabric.tools:gradle:1.27.1'


### PR DESCRIPTION
## Issue

Up until now the "Buy Ticket" Button was always visible for future events and the "Remaining Tickets" section was always visible for future and past events.

The changes in these commits ensure that:
- The "Buy Ticket" button is only displayed for future events for which there are (still) tickets available, while the "View Ticket" button remains visible for all events for which a ticket has been purchased by the user.
- The "Remaining Tickets" Section displays the number of remaining tickets if it is positive and a text explaining that tickets may still be available at the evening box office if the number of remaining tickets is zero. If the number of remaining tickets is negative, the "Remaining Tickets" section is hidden (can be used for events that do not sell tickets).

## Screenshot

[see screenshot album on imgur](https://imgur.com/a/939jy5N)

## Why this is useful for all students

This feature is especially useful for events that should be displayed as such, but do not want to sell tickets via the app (e.g. UNITY) or do not sell tickets at all (e.g. Diversityfilm, MaiTUM, TUNIX, GARNIX, ...). Otherwise people may end up confused wether they can still and/or need to purchase tickets.

