### PR TITLE
Temporarily fix show ticket crash

### DIFF
--- a/app/src/main/java/de/tum/in/tumcampusapp/component/ui/ticket/TicketTypeDao.java
+++ b/app/src/main/java/de/tum/in/tumcampusapp/component/ui/ticket/TicketTypeDao.java
@@ -1,12 +1,11 @@
 package de.tum.in.tumcampusapp.component.ui.ticket;
 
+import java.util.List;
+
 import androidx.room.Dao;
 import androidx.room.Insert;
 import androidx.room.OnConflictStrategy;
 import androidx.room.Query;
-
-import java.util.List;
-
 import de.tum.in.tumcampusapp.component.ui.ticket.model.TicketType;
 
 @Dao
@@ -18,8 +17,8 @@ public interface TicketTypeDao {
     @Query("SELECT * FROM ticket_types")
     List<TicketType> getAll();
 
-    @Query("SELECT * FROM ticket_types WHERE id = :id")
-    TicketType getById(int id);
+    @Query("SELECT * FROM ticket_types tt, tickets t WHERE tt.id = t.ticket_type_id AND t.event_id = :eventId")
+    List<TicketType> getByEventId(int eventId);
 
     @Query("DELETE FROM ticket_types")
     void flush();

--- a/app/src/main/java/de/tum/in/tumcampusapp/component/ui/ticket/activity/ShowTicketActivity.java
+++ b/app/src/main/java/de/tum/in/tumcampusapp/component/ui/ticket/activity/ShowTicketActivity.java
@@ -158,7 +158,7 @@ public class ShowTicketActivity extends BaseActivity {
     private void loadTicketData(int eventId) {
         List<TicketType> ticketTypes = ticketsLocalRepo.getTicketTypeByEventId(eventId);
         if (ticketTypes.isEmpty()) {
-            ticketsLocalRepo.addTicketTypes(ticketsRemoteRepo.fetchTicketTypesForEvent(23).blockingSingle());
+            ticketsLocalRepo.addTicketTypes(ticketsRemoteRepo.fetchTicketTypesForEvent(eventId).blockingSingle());
         }
         ticketInfoList = ticketsLocalRepo.getTicketsByEventId(eventId);
         event = eventsLocalRepo.getEventById(eventId);

--- a/app/src/main/java/de/tum/in/tumcampusapp/component/ui/ticket/activity/ShowTicketActivity.java
+++ b/app/src/main/java/de/tum/in/tumcampusapp/component/ui/ticket/activity/ShowTicketActivity.java
@@ -35,6 +35,7 @@ import de.tum.in.tumcampusapp.component.ui.ticket.di.TicketsModule;
 import de.tum.in.tumcampusapp.component.ui.ticket.model.Event;
 import de.tum.in.tumcampusapp.component.ui.ticket.model.Ticket;
 import de.tum.in.tumcampusapp.component.ui.ticket.model.TicketInfo;
+import de.tum.in.tumcampusapp.component.ui.ticket.model.TicketType;
 import de.tum.in.tumcampusapp.component.ui.ticket.repository.EventsLocalRepository;
 import de.tum.in.tumcampusapp.component.ui.ticket.repository.TicketsLocalRepository;
 import de.tum.in.tumcampusapp.component.ui.ticket.repository.TicketsRemoteRepository;
@@ -155,6 +156,10 @@ public class ShowTicketActivity extends BaseActivity {
     }
 
     private void loadTicketData(int eventId) {
+        List<TicketType> ticketTypes = ticketsLocalRepo.getTicketTypeByEventId(eventId);
+        if (ticketTypes.isEmpty()) {
+            ticketsLocalRepo.addTicketTypes(ticketsRemoteRepo.fetchTicketTypesForEvent(23).blockingSingle());
+        }
         ticketInfoList = ticketsLocalRepo.getTicketsByEventId(eventId);
         event = eventsLocalRepo.getEventById(eventId);
     }

--- a/app/src/main/java/de/tum/in/tumcampusapp/component/ui/ticket/activity/ShowTicketActivity.java
+++ b/app/src/main/java/de/tum/in/tumcampusapp/component/ui/ticket/activity/ShowTicketActivity.java
@@ -156,7 +156,7 @@ public class ShowTicketActivity extends BaseActivity {
     }
 
     private void loadTicketData(int eventId) {
-        List<TicketType> ticketTypes = ticketsLocalRepo.getTicketTypeByEventId(eventId);
+        List<TicketType> ticketTypes = ticketsLocalRepo.getTicketTypesByEventId(eventId);
         if (ticketTypes.isEmpty()) {
             ticketsLocalRepo.addTicketTypes(ticketsRemoteRepo.fetchTicketTypesForEvent(eventId).blockingSingle());
         }

--- a/app/src/main/java/de/tum/in/tumcampusapp/component/ui/ticket/repository/TicketsLocalRepository.kt
+++ b/app/src/main/java/de/tum/in/tumcampusapp/component/ui/ticket/repository/TicketsLocalRepository.kt
@@ -20,7 +20,7 @@ class TicketsLocalRepository @Inject constructor(
 
     fun getTicketsByEventId(eventId: Int): List<TicketInfo> = database.ticketDao().getByEventId(eventId)
 
-    fun getTicketTypeByEventId(eventId: Int): List<TicketType> = database.ticketTypeDao().getByEventId(eventId)
+    fun getTicketTypesByEventId(eventId: Int): List<TicketType> = database.ticketTypeDao().getByEventId(eventId)
 
     fun addTicketTypes(ticketTypes: List<TicketType>) {
         database.ticketTypeDao().insert(ticketTypes)

--- a/app/src/main/java/de/tum/in/tumcampusapp/component/ui/ticket/repository/TicketsLocalRepository.kt
+++ b/app/src/main/java/de/tum/in/tumcampusapp/component/ui/ticket/repository/TicketsLocalRepository.kt
@@ -20,7 +20,7 @@ class TicketsLocalRepository @Inject constructor(
 
     fun getTicketsByEventId(eventId: Int): List<TicketInfo> = database.ticketDao().getByEventId(eventId)
 
-    fun getTicketTypeById(id: Int): TicketType = database.ticketTypeDao().getById(id)
+    fun getTicketTypeByEventId(eventId: Int): List<TicketType> = database.ticketTypeDao().getByEventId(eventId)
 
     fun addTicketTypes(ticketTypes: List<TicketType>) {
         database.ticketTypeDao().insert(ticketTypes)


### PR DESCRIPTION
## Issue
#1286

App crashes because the ticket types are not downloaded and I cannot find the actual bug right now. I checked that the download method is called and it recognizes the login. The tickets themselves are downloaded right after the login.

For now I am explicitly downloading the ticket types for the ticket that should be displayed since there are upcoming events and about 7 users have unsuccessfully tried to access their tickets according to Crashlytics.