### PR TITLE
Update WeekView version

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -155,7 +155,7 @@ dependencies {
     implementation 'me.dm7.barcodescanner:zxing:1.9.13'
     implementation 'com.journeyapps:zxing-android-embedded:3.6.0'
     implementation 'de.psdev.licensesdialog:licensesdialog:2.0.0'
-    implementation 'com.github.thellmund:Android-Week-View:3.3'
+    implementation 'com.github.thellmund:Android-Week-View:3.4'
     implementation 'de.hdodenhof:circleimageview:3.0.0'
     implementation 'com.github.PhilJay:MPAndroidChart:v3.0.3'
     implementation 'com.makeramen:roundedimageview:2.3.0'

--- a/app/src/main/java/de/tum/in/tumcampusapp/component/tumui/calendar/WidgetCalendarItem.kt
+++ b/app/src/main/java/de/tum/in/tumcampusapp/component/tumui/calendar/WidgetCalendarItem.kt
@@ -23,8 +23,20 @@ data class WidgetCalendarItem(
     var isFirstOnDay: Boolean = false
 
     override fun toWeekViewEvent(): WeekViewEvent<WidgetCalendarItem> {
-        return WeekViewEvent(id.toLong(), title, startTime.toGregorianCalendar(),
-                endTime.toGregorianCalendar(), location, color, false, this)
+        val style = WeekViewEvent.Style.Builder()
+                .setBackgroundColor(color)
+                .build()
+
+        return WeekViewEvent.Builder<WidgetCalendarItem>()
+                .setId(id.toLong())
+                .setTitle(title)
+                .setStartTime(startTime.toGregorianCalendar())
+                .setEndTime(endTime.toGregorianCalendar())
+                .setLocation(location)
+                .setAllDay(false)
+                .setStyle(style)
+                .setData(this)
+                .build()
     }
 
     companion object {

--- a/app/src/main/java/de/tum/in/tumcampusapp/component/tumui/calendar/model/CalendarItem.kt
+++ b/app/src/main/java/de/tum/in/tumcampusapp/component/tumui/calendar/model/CalendarItem.kt
@@ -127,7 +127,7 @@ data class CalendarItem(
                 .setTextColor(textColor)
                 .setTextStrikeThrough(isCanceled)
                 .setBorderWidth(borderWidth)
-                .setBorderColor(color ?: 0)
+                .setBorderColor(color)
                 .build()
 
         return WeekViewEvent.Builder<CalendarItem>()

--- a/app/src/main/java/de/tum/in/tumcampusapp/component/tumui/calendar/model/CalendarItem.kt
+++ b/app/src/main/java/de/tum/in/tumcampusapp/component/tumui/calendar/model/CalendarItem.kt
@@ -1,6 +1,7 @@
 package de.tum.`in`.tumcampusapp.component.tumui.calendar.model
 
 import android.content.ContentValues
+import android.graphics.Color
 import android.provider.CalendarContract
 import androidx.room.Entity
 import androidx.room.Ignore
@@ -115,7 +116,29 @@ data class CalendarItem(
     }
 
     override fun toWeekViewEvent(): WeekViewEvent<CalendarItem> {
-        return WeekViewEvent(nr.toLong(), title, eventStart.toGregorianCalendar(),
-                eventEnd.toGregorianCalendar(), location, color ?: 0, false, this)
+        val color = checkNotNull(color) { "No color provided for CalendarItem" }
+
+        val backgroundColor = if (isCanceled) Color.WHITE else color
+        val textColor = if (isCanceled) color else Color.WHITE
+        val borderWidth = if (isCanceled) 2 else 0
+
+        val style = WeekViewEvent.Style.Builder()
+                .setBackgroundColor(backgroundColor)
+                .setTextColor(textColor)
+                .setTextStrikeThrough(isCanceled)
+                .setBorderWidth(borderWidth)
+                .setBorderColor(color ?: 0)
+                .build()
+
+        return WeekViewEvent.Builder<CalendarItem>()
+                .setId(nr.toLong())
+                .setTitle(title)
+                .setStartTime(eventStart.toGregorianCalendar())
+                .setEndTime(eventEnd.toGregorianCalendar())
+                .setLocation(location)
+                .setStyle(style)
+                .setAllDay(false)
+                .setData(this)
+                .build()
     }
 }


### PR DESCRIPTION
## Issue
I released a new version of [WeekView](https://github.com/thellmund/Android-Week-View) today. The new version allows to add a custom styling to event chips, e.g. adding a border and applying strike-through to the text. This seems like a great way to deal with canceled events, so I’m adding it with this pull request.

## Screenshot
![Screenshot_1557162083](https://user-images.githubusercontent.com/11819826/57241551-821a9780-7031-11e9-82c5-c64572bf16e5.png)

