### PR TITLE
Remove second 4,0 from grades

### DIFF
--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -153,7 +153,6 @@
         <item>4,3</item>
         <item>4,4</item>
         <item>4,7</item>
-        <item>4,0</item>
         <item>5,0</item>
     </string-array>
 </resources>


### PR DESCRIPTION
## Issue

This fixes the following issue(s): #1298
