### PR TITLE
Fix Privacy Policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,8 +33,7 @@ Just don't forget: Be excellent to each other :heart:
 This is not an official app of the Technische Universität München. There's no support or warranty (you can however send us an email [app@tum.de](mailto:app@tum.de) or open an issue here on Github). The app is developed by students and for students, so use it at your own risk. We try to keep your data safe with only using TUMonline tokens and not saving your password. For further information, please take a look at our privacy policy and the terms and conditions of the lecture chat.
 
 ## Policies:
-[Privacy policy](https://app.tum.de/landing/privacy/)  
-[T&Cs of the lecture chat](https://app.tum.de/landing/chatterms/)
+[Privacy policy](https://www.tum.app/privacy/)
 
 ## Support:
 You can reach us on [Facebook](https://www.facebook.com/TUMCampus), [Github](https://github.com/TUM-Dev/Campus-Android) or via E-Mail [app@tum.de](mailto:app@tum.de)

--- a/app/src/main/java/de/tum/in/tumcampusapp/component/ui/onboarding/WizNavExtrasActivity.java
+++ b/app/src/main/java/de/tum/in/tumcampusapp/component/ui/onboarding/WizNavExtrasActivity.java
@@ -83,7 +83,7 @@ public class WizNavExtrasActivity extends ActivityForLoadingInBackground<Void, C
     }
 
     public void onClickTerms(View view) {
-        Intent intent = new Intent(Intent.ACTION_VIEW, Uri.parse(getString(R.string.url_chat_terms)));
+        Intent intent = new Intent(Intent.ACTION_VIEW, Uri.parse(getString(R.string.url_privacy_policy)));
         startActivity(intent);
     }
 

--- a/app/src/main/java/de/tum/in/tumcampusapp/component/ui/overview/InformationActivity.kt
+++ b/app/src/main/java/de/tum/in/tumcampusapp/component/ui/overview/InformationActivity.kt
@@ -8,13 +8,13 @@ import android.content.pm.PackageManager.NameNotFoundException
 import android.net.Uri
 import android.os.Bundle
 import android.preference.PreferenceManager
-import androidx.core.content.pm.PackageInfoCompat
 import android.text.format.DateUtils
 import android.view.View
 import android.view.ViewGroup
 import android.widget.TableLayout
 import android.widget.TableRow
 import android.widget.TextView
+import androidx.core.content.pm.PackageInfoCompat
 import de.psdev.licensesdialog.LicensesDialog
 import de.tum.`in`.tumcampusapp.BuildConfig
 import de.tum.`in`.tumcampusapp.R
@@ -42,9 +42,6 @@ class InformationActivity : BaseActivity(R.layout.activity_information) {
         }
         button_privacy.setOnClickListener {
             startActivity(Intent(ACTION_VIEW, Uri.parse(getString(R.string.url_privacy_policy))))
-        }
-        button_chat_terms.setOnClickListener {
-            startActivity(Intent(ACTION_VIEW, Uri.parse(getString(R.string.url_chat_terms))))
         }
         button_licenses.setOnClickListener {
             LicensesDialog.Builder(this)

--- a/app/src/main/res/layout/activity_information.xml
+++ b/app/src/main/res/layout/activity_information.xml
@@ -71,17 +71,6 @@
                     app:cornerRadius="@dimen/material_corner_radius" />
 
                 <com.google.android.material.button.MaterialButton
-                    android:id="@+id/button_chat_terms"
-                    style="@style/Widget.MaterialComponents.Button"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:layout_marginStart="@dimen/material_default_padding"
-                    android:layout_marginEnd="@dimen/material_default_padding"
-                    android:text="@string/open_chat_terms"
-                    android:textAllCaps="false"
-                    app:cornerRadius="@dimen/material_corner_radius" />
-
-                <com.google.android.material.button.MaterialButton
                     android:id="@+id/button_licenses"
                     style="@style/Widget.MaterialComponents.Button"
                     android:layout_width="match_parent"

--- a/app/src/main/res/layout/activity_wiznav_extras.xml
+++ b/app/src/main/res/layout/activity_wiznav_extras.xml
@@ -69,17 +69,6 @@
                     android:text="@string/set_lecture_chat"
                     android:textSize="15sp" />
 
-                <com.google.android.material.button.MaterialButton
-                    style="@style/Widget.MaterialComponents.Button.OutlinedButton"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:layout_marginStart="@dimen/material_small_padding"
-                    android:onClick="onClickTerms"
-                    android:text="@string/open_chat_terms"
-                    android:textAllCaps="false"
-                    android:textColor="@color/color_primary"
-                    app:cornerRadius="@dimen/material_corner_radius" />
-
                 <CheckBox
                     android:id="@+id/chk_bug_reports"
                     android:layout_width="wrap_content"
@@ -96,6 +85,19 @@
                     android:padding="@dimen/padding_default"
                     android:text="@string/set_bug_reports"
                     android:textSize="15sp" />
+
+                <com.google.android.material.button.MaterialButton
+                    style="@style/Widget.MaterialComponents.Button.OutlinedButton"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_gravity="center_horizontal"
+                    android:layout_marginStart="@dimen/material_small_padding"
+                    android:layout_marginTop="@dimen/material_default_padding"
+                    android:onClick="onClickTerms"
+                    android:text="@string/privacy_policy"
+                    android:textAllCaps="false"
+                    android:textColor="@color/color_primary"
+                    app:cornerRadius="@dimen/material_corner_radius" />
 
             </LinearLayout>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -381,8 +381,7 @@
     <string name="vibration">Vibration</string>
     <string name="silent">Silent</string>
     <string name="mode_silent_mode">State during lectures</string>
-    <string name="url_privacy_policy" translatable="false">https://app.tum.de/landing/privacy/</string>
-    <string name="url_chat_terms" translatable="false">https://app.tum.de/landing/chatterms/</string>
+    <string name="url_privacy_policy" translatable="false">https://www.tum.app/privacy</string>
     <string name="privacy_policy">Privacy Policy</string>
     <string name="message_details">Message info</string>
     <string name="message_detail_text">&lt;b>Sender&lt;/b>&lt;br>

--- a/fastlane/metadata/android/de-DE/full_description.txt
+++ b/fastlane/metadata/android/de-DE/full_description.txt
@@ -12,12 +12,9 @@ Support: https://www.facebook.com/TUMCampus / app@tum.de
 Wichtiger Hinweis:
 Dies ist keine offizielle App der Technischen Universität München. Es erfolgt daher auch kein offizieller Support oder eine Haftung. Die App wird von und für Studierende entwickelt.
 
-Datenschutzerklärung: https://app.tum.de/landing/privacy/
-Chatbedingungen: https://app.tum.de/landing/chatterms/
-
-Berechtigungen und die Gründe:
+Berechtigungen und deren Gründe:
 - Standort abfragen: Um immer aktuelle Informationen zum aktuellen Standort anzuzeigen, wie z.B. Mensa Menü, MVV Abfahrtszeiten, ....
-- Kontakte ändern: Damit in der Personensuche mit einem Klick die Kontaktdaten eines Komilitonen oder TU Mitarbeiters in die Kontakte eingefügt werden koennen
+- Kontakte ändern: Damit in der Personensuche mit einem Klick die Kontaktdaten eines Kommilitonen oder TU Mitarbeiters in die Kontakte eingefügt werden können
 - Kalendertermine lesen/ändern: Damit sich die Vorlesungstermine mit dem Google Kalender synchronisieren lassen 
 - SD-Karteninhalte ändern oder löschen: Damit die App Daten zwischenspeichern kann und damit das Laden beschleunigt wird.
 - Konten auf dem Gerät suchen: Wird für die Chatfunktion benötigt, da dafür ein Google Account benötigt wird.

--- a/fastlane/metadata/android/en-US/full_description.txt
+++ b/fastlane/metadata/android/en-US/full_description.txt
@@ -11,13 +11,11 @@ The TUM Campus Apps is being developed by students and volunteers. It can be use
 The app is intended for both students and employees!
 
 Developers and other involved people:
-https://github.com/TCA-Team/TumCampusApp/blob/master/CONTRIBUTORS.md
+https://github.com/TUM-Dev/TumCampusApp/blob/master/CONTRIBUTORS.md
 
 Support: https://www.facebook.com/TUMCampus / app@tum.de
 
 Disclaimer: This is not an official app of the TU Munich and there is consequentially no official support or liability. 
-
-Chat Terms: https://app.tum.de/landing/chatterms/
 
 Permissions and what they are used for:
 - Location services: so we can show you nearest Cafeteria / MVV departures
@@ -29,4 +27,4 @@ Permissions and what they are used for:
 - Disable sleep mode: to receive messages when the display is turned off
 
 License: GNU GPL v3 - http://www.gnu.org/licenses/gpl.html
-The source code is available on GitHub: https://github.com/TCA-Team/
+The source code is available on GitHub: https://github.com/TUM-Dev/


### PR DESCRIPTION
## Issue

This fixes the following issue(s): #1330 

Old chat terms not available anymore, will add some information about the chat to the privacy policy. 
--> Rename chat terms button to privacy policy, change links in README and play store listing

### Associated Changes
- [x] Privacy policy link and other changes in this PR concerning google play store listing have already been published to google play
- [ ] Add some information concerning the chat to the privacy policy page (https://github.com/TUM-Dev/Website/blob/master/_pages/privacy.html)
