### PR TITLE
Minor bug fixes

### DIFF
--- a/app/src/main/java/de/tum/in/tumcampusapp/component/other/generic/adapter/NoResultsAdapter.kt
+++ b/app/src/main/java/de/tum/in/tumcampusapp/component/other/generic/adapter/NoResultsAdapter.kt
@@ -15,7 +15,7 @@ class NoResultsAdapter(context: Context) :
         ArrayAdapter<String>(context, R.layout.listview_simple_item_center, arrayOf(context.getString(R.string.no_search_result))), StickyListHeadersAdapter {
 
     // Generate header view
-    override fun getHeaderView(pos: Int, convertView: View, parent: ViewGroup) = View(context)
+    override fun getHeaderView(pos: Int, convertView: View?, parent: ViewGroup) = View(context)
 
     override fun getHeaderId(i: Int): Long = 0
 

--- a/app/src/main/java/de/tum/in/tumcampusapp/component/tumui/calendar/NextLectureCardViewHolder.kt
+++ b/app/src/main/java/de/tum/in/tumcampusapp/component/tumui/calendar/NextLectureCardViewHolder.kt
@@ -54,7 +54,8 @@ class NextLectureCardViewHolder(
         val icon = if (isExpanded) R.drawable.ic_arrow_up_blue else R.drawable.ic_arrow_down_blue
         moreTextView.addCompoundDrawablesWithIntrinsicBounds(start = icon)
 
-        TransitionManager.beginDelayedTransition(this as ViewGroup)
+        // If possible, run the transition on the parent RecyclerView to incorporate sibling views
+        TransitionManager.beginDelayedTransition((this.parent ?: this) as ViewGroup)
     }
 
     private fun showLecture(lecture: NextLectureCard.CardCalendarItem) = with(itemView) {


### PR DESCRIPTION
- Fixes overlapping of list items when expanding/collapsing the next lecture card on the start page by running the respective transition not on the card itself but on the parent RecyclerView, making sure that y position changes of sibling views positioned below take part in the animation.

- Fixes a NPE that occured when trying to display lists dependent on instances of NoResultsAdapter because of Kotlin instrinsic null checks. A java api function parameter nullable by design had been declared non null in the Kotlin implementation.

