### PR TITLE
Interpret Event Location as HTML

### DIFF
--- a/app/src/main/java/de/tum/in/tumcampusapp/component/tumui/calendar/model/Event.kt
+++ b/app/src/main/java/de/tum/in/tumcampusapp/component/tumui/calendar/model/Event.kt
@@ -12,6 +12,7 @@ import de.tum.`in`.tumcampusapp.component.notifications.persistence.Notification
 import de.tum.`in`.tumcampusapp.component.other.locations.model.Geo
 import de.tum.`in`.tumcampusapp.utils.Const
 import de.tum.`in`.tumcampusapp.utils.DateTimeUtils
+import de.tum.`in`.tumcampusapp.utils.Utils
 import org.joda.time.DateTime
 
 @Xml(name = "event")
@@ -37,7 +38,7 @@ data class Event(
         return CalendarItem(
                 id ?: "", status ?: "", url ?: "", title,
                 description ?: "", startTime ?: DateTime(),
-                endTime ?: DateTime(), location ?: "", false
+                endTime ?: DateTime(), Utils.stripHtml(location ?: ""), false
         )
     }
 


### PR DESCRIPTION
## Issue

This fixes the following issue(s):

The calendar events were showing escaped HTML entities. For example, "Hörsaal 1, &qout;Interims I&qout;".

## Screenshot
| Before | After |
| --------- | ------ |
| ![image](https://user-images.githubusercontent.com/22001111/67622809-604ee000-f81e-11e9-8304-0ca65d132f4a.png) | ![image](https://user-images.githubusercontent.com/22001111/67622839-b4f25b00-f81e-11e9-8b3d-471ecb2fda86.png) |
