### PR TITLE
fix settings crash when not logged in

### DIFF
--- a/app/src/main/java/de/tum/in/tumcampusapp/component/other/settings/SettingsFragment.kt
+++ b/app/src/main/java/de/tum/in/tumcampusapp/component/other/settings/SettingsFragment.kt
@@ -76,7 +76,7 @@ class SettingsFragment : PreferenceFragmentCompat(), Preference.OnPreferenceClic
             if (silentSwitch != null) {
                 silentSwitch.isEnabled = false
             }
-            logoutButton.isVisible = false
+            logoutButton?.isVisible = false
         }
 
         // Only do these things if we are in the root of the preferences


### PR DESCRIPTION
fixes #1368
Behold: The largest PR yet.

This was crashing because `findPreference(BUTTON_LOGOUT)` returns null when the `rootKey` is not null (e.g. when the root is mvv_card, the logout_button in not in scope as we are not on the main settings page.)

Simply sanitizing this like I did works fine but we could also hide the logout button only if the root is null.