### PR TITLE
added darkmode support for alarm

### DIFF
--- a/app/src/main/java/de/tum/in/tumcampusapp/component/ui/alarm/AlarmActivity.kt
+++ b/app/src/main/java/de/tum/in/tumcampusapp/component/ui/alarm/AlarmActivity.kt
@@ -5,6 +5,7 @@ import android.graphics.Color
 import android.os.Bundle
 import android.webkit.WebView
 import android.widget.TextView
+import androidx.core.content.ContextCompat
 import de.tum.`in`.tumcampusapp.R
 import de.tum.`in`.tumcampusapp.component.other.generic.activity.BaseActivity
 import de.tum.`in`.tumcampusapp.component.ui.alarm.model.FcmNotification
@@ -40,8 +41,27 @@ class AlarmActivity : BaseActivity(R.layout.activity_alarmdetails) {
         Utils.log(notification.toString())
 
         this.mTitle.text = notification.title
-        this.mDescription.loadDataWithBaseURL(null, notification.description, "text/html", "utf-8", null)
+        this.mDescription.loadDataWithBaseURL(null, formatDescription(notification.description), "text/html", "utf-8", null)
         this.mDescription.setBackgroundColor(Color.TRANSPARENT)
         this.mDate.text = DateTimeUtils.getDateString(notification.created)
+    }
+
+    private fun formatDescription(description: String): String {
+        val color = ContextCompat.getColor(this, R.color.text_primary)
+        val hexColor = "#" + String.format("%06X", color and 0x00ffffff)
+
+        val preHTML = "<!DOCTYPE HTML>\n" +
+                "<html>\n" +
+                "<head>\n" +
+                "<style type=\"text/css\">\n" +
+                "body{color: " + hexColor + ";}\n" +
+                "</style>\n" +
+                "</head>\n" +
+                "<body>\n"
+
+        val postHTML = "\n</body>\n" +
+                "</html>"
+
+        return preHTML + description + postHTML
     }
 }


### PR DESCRIPTION
The last test alarm didn't look too well in dark mode. The alarm description is shown in a WebView, which basically parses the html. To have a white text color in the dark mode I had to wrap the received html data from the server with some custom css.

Couldn't test it with a real alarm, but triggered to open some test activity and show me the modified html data. The text color should work properly now.