### PR TITLE
Added ISRG Root X1 as an alternative to DST Root CA X3

### DIFF
--- a/app/src/main/java/de/tum/in/tumcampusapp/api/app/ApiHelper.java
+++ b/app/src/main/java/de/tum/in/tumcampusapp/api/app/ApiHelper.java
@@ -49,6 +49,7 @@ public final class ApiHelper {
                 .add(API_HOSTNAME, "sha256/0d4q5hyN8vpiOWYWPUxz1GC/xCjldYW+a/65pWMj0bY=") //Deutsche Telekom Root CA 2
                 .add(API_HOSTNAME, "sha256/YLh1dUR9y6Kja30RrAn7JKnbQG/uEtLMkBgFF2Fuihg=") //Let's Encrypt Authority X3
                 .add(API_HOSTNAME, "sha256/Vjs8r4z+80wjNcr1YKepWQboSIRi63WsWXhIMN+eWys=") //LE Cross Sign: DST Root CA X3
+                .add(API_HOSTNAME, "sha256/C5+lpZ7tcVwmwQIMcRtPbsQtWLABXhQzejna0wHFr8M=") //LE Root: ISRG Root X1
                 .add(API_HOSTNAME_NEW, "sha256/dVphPQ9xG7woPpEKXrNalw4eMUQ4Fw9r3OXTzxfuL5A=") //Fakultaet fuer Informatik
                 .add(API_HOSTNAME_NEW, "sha256/SwdQoHL7SB/6o12XsIhbQJ9bANVnbrJoHTLzlu/qXT0=") //Technische Universitaet Muenchen
                 .add(API_HOSTNAME_NEW, "sha256/VzL+FtAKvzb4N5igmFJyv83GD7CBK7Yyw+R6XdRRfmg=") //DFN-Verein PCA Global


### PR DESCRIPTION
## Issue

This fixes the following issue(s):

A certificate pinning issue occured when calling app.tum.app which I assume was caused by an updated Let's Encrypt configuration. I was able to work around that by adding Let's Encrypts own root cert named ISRG Root X1 to the pinned certs. In theory this cert and the DST Root CA X3 should both be applicable due to cross-signing, but in practice it seems like the former is necessary. Keep in mind I have only tested this on one device from one network.

## Error log
This is the error log of the original cert pinning exception:
```
E/BaseFragment: javax.net.ssl.SSLPeerUnverifiedException: Certificate pinning failure!
      Peer certificate chain:
        sha256/QKjrwUVYC8PvWJohpWvXnaxAdnUI9U7typ3im/ofwVk=: CN=app.tum.app
        sha256/jQJTbIh0grw0/1TkHSumWb+Fs0Ggogr621gT3PvPKG0=: CN=R3,O=Let's Encrypt,C=US
        sha256/C5+lpZ7tcVwmwQIMcRtPbsQtWLABXhQzejna0wHFr8M=: CN=ISRG Root X1,O=Internet Security Research Group,C=US
      Pinned certificates for tumcabe.in.tum.de:
        sha256/dVphPQ9xG7woPpEKXrNalw4eMUQ4Fw9r3OXTzxfuL5A=
        sha256/SwdQoHL7SB/6o12XsIhbQJ9bANVnbrJoHTLzlu/qXT0=
        sha256/VzL+FtAKvzb4N5igmFJyv83GD7CBK7Yyw+R6XdRRfmg=
        sha256/0d4q5hyN8vpiOWYWPUxz1GC/xCjldYW+a/65pWMj0bY=
        sha256/YLh1dUR9y6Kja30RrAn7JKnbQG/uEtLMkBgFF2Fuihg=
        sha256/Vjs8r4z+80wjNcr1YKepWQboSIRi63WsWXhIMN+eWys=
    javax.net.ssl.SSLPeerUnverifiedException: Certificate pinning failure!
      Peer certificate chain:
        sha256/QKjrwUVYC8PvWJohpWvXnaxAdnUI9U7typ3im/ofwVk=: CN=app.tum.app
        sha256/jQJTbIh0grw0/1TkHSumWb+Fs0Ggogr621gT3PvPKG0=: CN=R3,O=Let's Encrypt,C=US
        sha256/C5+lpZ7tcVwmwQIMcRtPbsQtWLABXhQzejna0wHFr8M=: CN=ISRG Root X1,O=Internet Security Research Group,C=US
      Pinned certificates for tumcabe.in.tum.de:
        sha256/dVphPQ9xG7woPpEKXrNalw4eMUQ4Fw9r3OXTzxfuL5A=
        sha256/SwdQoHL7SB/6o12XsIhbQJ9bANVnbrJoHTLzlu/qXT0=
        sha256/VzL+FtAKvzb4N5igmFJyv83GD7CBK7Yyw+R6XdRRfmg=
        sha256/0d4q5hyN8vpiOWYWPUxz1GC/xCjldYW+a/65pWMj0bY=
        sha256/YLh1dUR9y6Kja30RrAn7JKnbQG/uEtLMkBgFF2Fuihg=
        sha256/Vjs8r4z+80wjNcr1YKepWQboSIRi63WsWXhIMN+eWys=
        at okhttp3.CertificatePinner.check$okhttp(CertificatePinner.kt:200)
        at okhttp3.internal.connection.RealConnection.connectTls(RealConnection.kt:410)
        at okhttp3.internal.connection.RealConnection.establishProtocol(RealConnection.kt:337)
        at okhttp3.internal.connection.RealConnection.connect(RealConnection.kt:209)
        at okhttp3.internal.connection.ExchangeFinder.findConnection(ExchangeFinder.kt:226)
        at okhttp3.internal.connection.ExchangeFinder.findHealthyConnection(ExchangeFinder.kt:106)
        at okhttp3.internal.connection.ExchangeFinder.find(ExchangeFinder.kt:74)
        at okhttp3.internal.connection.RealCall.initExchange$okhttp(RealCall.kt:255)
        at okhttp3.internal.connection.ConnectInterceptor.intercept(ConnectInterceptor.kt:32)
        at okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.kt:109)
        at okhttp3.internal.cache.CacheInterceptor.intercept(CacheInterceptor.kt:95)
        at okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.kt:109)
        at okhttp3.internal.http.BridgeInterceptor.intercept(BridgeInterceptor.kt:83)
        at okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.kt:109)
        at okhttp3.internal.http.RetryAndFollowUpInterceptor.intercept(RetryAndFollowUpInterceptor.kt:76)
        at okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.kt:109)
        at de.tum.in.tumcampusapp.api.app.ChaosMonkeyInterceptor.intercept(ChaosMonkeyInterceptor.kt:27)
        at okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.kt:109)
        at de.tum.in.tumcampusapp.api.app.ApiHelper.lambda$getDeviceInterceptor$2(ApiHelper.java:124)
        at de.tum.in.tumcampusapp.api.app.-$$Lambda$ApiHelper$Ed6Z45oC4dmTmrD4C58bWLoLAoM.intercept(Unknown Source:4)
        at okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.kt:109)
        at de.tum.in.tumcampusapp.api.app.ApiHelper.lambda$disableGzip$1(ApiHelper.java:99)
        at de.tum.in.tumcampusapp.api.app.-$$Lambda$ApiHelper$OUC4myTOllc53YNAK_DOFdZp_xU.intercept(Unknown Source:0)
        at okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.kt:109)
        at okhttp3.internal.connection.RealCall.getResponseWithInterceptorChain$okhttp(RealCall.kt:201)
        at okhttp3.internal.connection.RealCall$AsyncCall.run(RealCall.kt:517)
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1162)
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:636)
        at java.lang.Thread.run(Thread.java:764)
```

## Why this is useful for all students
The app works, for example the study rooms page would not load before the fix.
