### PR TITLE
Remove certificate pinning

### DIFF
--- a/app/src/main/java/de/tum/in/tumcampusapp/api/app/ApiHelper.java
+++ b/app/src/main/java/de/tum/in/tumcampusapp/api/app/ApiHelper.java
@@ -42,33 +42,12 @@ public final class ApiHelper {
             return client;
         }
 
-        final CertificatePinner certificatePinner = new CertificatePinner.Builder()
-                .add(API_HOSTNAME, "sha256/dVphPQ9xG7woPpEKXrNalw4eMUQ4Fw9r3OXTzxfuL5A=") //Fakultaet fuer Informatik
-                .add(API_HOSTNAME, "sha256/SwdQoHL7SB/6o12XsIhbQJ9bANVnbrJoHTLzlu/qXT0=") //Technische Universitaet Muenchen
-                .add(API_HOSTNAME, "sha256/VzL+FtAKvzb4N5igmFJyv83GD7CBK7Yyw+R6XdRRfmg=") //DFN-Verein PCA Global
-                .add(API_HOSTNAME, "sha256/0d4q5hyN8vpiOWYWPUxz1GC/xCjldYW+a/65pWMj0bY=") //Deutsche Telekom Root CA 2
-                .add(API_HOSTNAME, "sha256/YLh1dUR9y6Kja30RrAn7JKnbQG/uEtLMkBgFF2Fuihg=") //Let's Encrypt Authority X3
-                .add(API_HOSTNAME, "sha256/Vjs8r4z+80wjNcr1YKepWQboSIRi63WsWXhIMN+eWys=") //LE Cross Sign: DST Root CA X3
-                .add(API_HOSTNAME_NEW, "sha256/dVphPQ9xG7woPpEKXrNalw4eMUQ4Fw9r3OXTzxfuL5A=") //Fakultaet fuer Informatik
-                .add(API_HOSTNAME_NEW, "sha256/SwdQoHL7SB/6o12XsIhbQJ9bANVnbrJoHTLzlu/qXT0=") //Technische Universitaet Muenchen
-                .add(API_HOSTNAME_NEW, "sha256/VzL+FtAKvzb4N5igmFJyv83GD7CBK7Yyw+R6XdRRfmg=") //DFN-Verein PCA Global
-                .add(API_HOSTNAME_NEW, "sha256/0d4q5hyN8vpiOWYWPUxz1GC/xCjldYW+a/65pWMj0bY=") //Deutsche Telekom Root CA 2
-                .add(API_HOSTNAME_NEW, "sha256/YLh1dUR9y6Kja30RrAn7JKnbQG/uEtLMkBgFF2Fuihg=") //Let's Encrypt Authority X3
-                .add(API_HOSTNAME_NEW, "sha256/Vjs8r4z+80wjNcr1YKepWQboSIRi63WsWXhIMN+eWys=") //LE Cross Sign: DST Root CA X3
-                .add(STUDY_ROOMS_HOSTNAME, "sha256/dVphPQ9xG7woPpEKXrNalw4eMUQ4Fw9r3OXTzxfuL5A=") //wwwv2.tum.de
-                .add(STUDY_ROOMS_HOSTNAME, "sha256/K64RzAqr/RSxwfpHN6fe0DcmdaIVmzAyi511ufYaK1s=") //wwwv4.tum.de
-                .add(STUDY_ROOMS_HOSTNAME, "sha256/SwdQoHL7SB/6o12XsIhbQJ9bANVnbrJoHTLzlu/qXT0=") //Zertifizierungsstelle der TUM
-                .add(STUDY_ROOMS_HOSTNAME, "sha256/VzL+FtAKvzb4N5igmFJyv83GD7CBK7Yyw+R6XdRRfmg=") //DFN-Verein PCA Global - G01
-                .add(STUDY_ROOMS_HOSTNAME, "sha256/0d4q5hyN8vpiOWYWPUxz1GC/xCjldYW+a/65pWMj0bY=") //Deutsche Telekom Root CA 2
-                .build();
-
         //We want to persist our cookies through app session
         CookieJar cookieJar = new PersistentCookieJar(new SetCookieCache(), new SharedPrefsCookiePersistor(c));
 
         //Start building the http client
         OkHttpClient.Builder builder = new OkHttpClient.Builder()
-                .cookieJar(cookieJar)
-                .certificatePinner(certificatePinner);
+                .cookieJar(cookieJar);
 
         // Disable gzip for requests as TUMonline
         builder.addInterceptor(ApiHelper.disableGzip());


### PR DESCRIPTION
## Issue

This fixes the following issue(s):

Certificate pinning has proven to be painful. I consider most data we transfer to be non critical and suggest removing it to prevent outages like the current one. With these changes, all tcabe related network calls work again.

Bonus: For me the login works now, unsure if this has anything to do with my changes.

