### PR TITLE
Parse html escape sequences in lecture text

### DIFF
--- a/app/src/main/java/de/tum/in/tumcampusapp/api/tumonline/converters/EscapedStringConverter.kt
+++ b/app/src/main/java/de/tum/in/tumcampusapp/api/tumonline/converters/EscapedStringConverter.kt
@@ -4,8 +4,7 @@ import android.os.Build
 import android.text.Html
 import com.tickaroo.tikxml.TypeConverter
 
-
-class EscapedStringConverter : TypeConverter<String>{
+class EscapedStringConverter : TypeConverter<String> {
 
     /**
      * Parses leftover html escape sequences
@@ -17,7 +16,7 @@ class EscapedStringConverter : TypeConverter<String>{
         // preserve newlines
         val str = value.replace("\n", "<br />")
 
-        return if(Build.VERSION.SDK_INT >= 24) {
+        return if (Build.VERSION.SDK_INT >= 24) {
             Html.fromHtml(str, Html.FROM_HTML_MODE_LEGACY).toString()
         } else {
             Html.fromHtml(str).toString()
@@ -31,5 +30,4 @@ class EscapedStringConverter : TypeConverter<String>{
     override fun write(value: String): String {
         return value
     }
-
 }

--- a/app/src/main/java/de/tum/in/tumcampusapp/api/tumonline/converters/EscapedStringConverter.kt
+++ b/app/src/main/java/de/tum/in/tumcampusapp/api/tumonline/converters/EscapedStringConverter.kt
@@ -1,0 +1,35 @@
+package de.tum.`in`.tumcampusapp.api.tumonline.converters
+
+import android.os.Build
+import android.text.Html
+import com.tickaroo.tikxml.TypeConverter
+
+
+class EscapedStringConverter : TypeConverter<String>{
+
+    /**
+     * Parses leftover html escape sequences
+     *
+     * @param value String with leftover escape sequences
+     * @return unescaped String
+     */
+    private fun unescapeString(value: String): String {
+        // preserve newlines
+        val str = value.replace("\n", "<br />")
+
+        return if(Build.VERSION.SDK_INT >= 24) {
+            Html.fromHtml(str, Html.FROM_HTML_MODE_LEGACY).toString()
+        } else {
+            Html.fromHtml(str).toString()
+        }
+    }
+
+    override fun read(value: String): String {
+        return unescapeString(value)
+    }
+
+    override fun write(value: String): String {
+        return value
+    }
+
+}

--- a/app/src/main/java/de/tum/in/tumcampusapp/api/tumonline/converters/NullableEscapedStringConverter.kt
+++ b/app/src/main/java/de/tum/in/tumcampusapp/api/tumonline/converters/NullableEscapedStringConverter.kt
@@ -4,8 +4,7 @@ import android.os.Build
 import android.text.Html
 import com.tickaroo.tikxml.TypeConverter
 
-
-class NullableEscapedStringConverter : TypeConverter<String?>{
+class NullableEscapedStringConverter : TypeConverter<String?> {
 
     /**
      * Parses leftover html escape sequences
@@ -17,7 +16,7 @@ class NullableEscapedStringConverter : TypeConverter<String?>{
         // preserve newlines
         val str = value.replace("\n", "<br />")
 
-        return if(Build.VERSION.SDK_INT >= 24) {
+        return if (Build.VERSION.SDK_INT >= 24) {
             Html.fromHtml(str, Html.FROM_HTML_MODE_LEGACY).toString()
         } else {
             Html.fromHtml(str).toString()
@@ -34,5 +33,4 @@ class NullableEscapedStringConverter : TypeConverter<String?>{
     override fun write(value: String?): String? {
         return value
     }
-
 }

--- a/app/src/main/java/de/tum/in/tumcampusapp/api/tumonline/converters/NullableEscapedStringConverter.kt
+++ b/app/src/main/java/de/tum/in/tumcampusapp/api/tumonline/converters/NullableEscapedStringConverter.kt
@@ -1,0 +1,38 @@
+package de.tum.`in`.tumcampusapp.api.tumonline.converters
+
+import android.os.Build
+import android.text.Html
+import com.tickaroo.tikxml.TypeConverter
+
+
+class NullableEscapedStringConverter : TypeConverter<String?>{
+
+    /**
+     * Parses leftover html escape sequences
+     *
+     * @param value String with leftover escape sequences
+     * @return unescaped String
+     */
+    private fun unescapeString(value: String): String {
+        // preserve newlines
+        val str = value.replace("\n", "<br />")
+
+        return if(Build.VERSION.SDK_INT >= 24) {
+            Html.fromHtml(str, Html.FROM_HTML_MODE_LEGACY).toString()
+        } else {
+            Html.fromHtml(str).toString()
+        }
+    }
+
+    override fun read(value: String?): String? {
+        value?.let {
+            return unescapeString(value)
+        }
+        return null
+    }
+
+    override fun write(value: String?): String? {
+        return value
+    }
+
+}

--- a/app/src/main/java/de/tum/in/tumcampusapp/component/tumui/lectures/model/Lecture.kt
+++ b/app/src/main/java/de/tum/in/tumcampusapp/component/tumui/lectures/model/Lecture.kt
@@ -2,6 +2,8 @@ package de.tum.`in`.tumcampusapp.component.tumui.lectures.model
 
 import com.tickaroo.tikxml.annotation.PropertyElement
 import com.tickaroo.tikxml.annotation.Xml
+import de.tum.`in`.tumcampusapp.api.tumonline.converters.EscapedStringConverter
+import de.tum.`in`.tumcampusapp.api.tumonline.converters.NullableEscapedStringConverter
 import de.tum.`in`.tumcampusapp.component.other.generic.adapter.SimpleStickyListHeadersAdapter
 
 /**
@@ -10,21 +12,21 @@ import de.tum.`in`.tumcampusapp.component.other.generic.adapter.SimpleStickyList
  */
 @Xml(name = "row")
 data class Lecture(
-    @PropertyElement(name = "dauer_info") val duration: String = "",
-    @PropertyElement(name = "org_kennung_betreut") val chairTumId: String? = null,
-    @PropertyElement(name = "org_name_betreut") val chairName: String? = null,
+    @PropertyElement(name = "dauer_info", converter = EscapedStringConverter::class) val duration: String = "",
+    @PropertyElement(name = "org_kennung_betreut", converter = NullableEscapedStringConverter::class) val chairTumId: String? = null,
+    @PropertyElement(name = "org_name_betreut", converter = NullableEscapedStringConverter::class) val chairName: String? = null,
     @PropertyElement(name = "org_nr_betreut") val chairId: Int? = null,
-    @PropertyElement(name = "semester") val semester: String,
-    @PropertyElement(name = "semester_id") val semesterId: String,
-    @PropertyElement(name = "semester_name") val semesterName: String,
-    @PropertyElement(name = "sj_name") val semesterYears: String,
-    @PropertyElement(name = "stp_lv_art_kurz") val shortLectureType: String,
-    @PropertyElement(name = "stp_lv_art_name") val lectureType: String,
-    @PropertyElement(name = "stp_lv_nr") val lectureId: String, // TODO: Rename variables
-    @PropertyElement(name = "stp_sp_nr") val stp_sp_nr: String,
-    @PropertyElement(name = "stp_sp_sst") val stp_sp_sst: String,
-    @PropertyElement(name = "stp_sp_titel") val title: String,
-    @PropertyElement(name = "vortragende_mitwirkende") val lecturers: String? = null
+    @PropertyElement(name = "semester", converter = EscapedStringConverter::class) val semester: String,
+    @PropertyElement(name = "semester_id", converter = EscapedStringConverter::class) val semesterId: String,
+    @PropertyElement(name = "semester_name", converter = EscapedStringConverter::class) val semesterName: String,
+    @PropertyElement(name = "sj_name", converter = EscapedStringConverter::class) val semesterYears: String,
+    @PropertyElement(name = "stp_lv_art_kurz", converter = EscapedStringConverter::class) val shortLectureType: String,
+    @PropertyElement(name = "stp_lv_art_name", converter = EscapedStringConverter::class) val lectureType: String,
+    @PropertyElement(name = "stp_lv_nr", converter = EscapedStringConverter::class) val lectureId: String, // TODO: Rename variables
+    @PropertyElement(name = "stp_sp_nr", converter = EscapedStringConverter::class) val stp_sp_nr: String,
+    @PropertyElement(name = "stp_sp_sst", converter = EscapedStringConverter::class) val stp_sp_sst: String,
+    @PropertyElement(name = "stp_sp_titel", converter = EscapedStringConverter::class) val title: String,
+    @PropertyElement(name = "vortragende_mitwirkende", converter = NullableEscapedStringConverter::class) val lecturers: String? = null
 ) : Comparable<Lecture>, SimpleStickyListHeadersAdapter.SimpleStickyListItem {
 
     override fun compareTo(other: Lecture) = other.semesterId.compareTo(semesterId)

--- a/app/src/main/java/de/tum/in/tumcampusapp/component/tumui/lectures/model/LectureAppointment.kt
+++ b/app/src/main/java/de/tum/in/tumcampusapp/component/tumui/lectures/model/LectureAppointment.kt
@@ -3,6 +3,7 @@ package de.tum.`in`.tumcampusapp.component.tumui.lectures.model
 import com.tickaroo.tikxml.annotation.PropertyElement
 import com.tickaroo.tikxml.annotation.Xml
 import de.tum.`in`.tumcampusapp.api.tumonline.converters.DateTimeConverter
+import de.tum.`in`.tumcampusapp.api.tumonline.converters.NullableEscapedStringConverter
 import org.joda.time.DateTime
 
 /**
@@ -11,13 +12,13 @@ import org.joda.time.DateTime
  */
 @Xml(name = "row")
 data class LectureAppointment(
-    @PropertyElement(name = "art") val type: String? = null,
+    @PropertyElement(name = "art", converter = NullableEscapedStringConverter::class) val type: String? = null,
     @PropertyElement(name = "beginn_datum_zeitpunkt", converter = DateTimeConverter::class) val startTime: DateTime,
     @PropertyElement(name = "ende_datum_zeitpunkt", converter = DateTimeConverter::class) val endTime: DateTime,
-    @PropertyElement(name = "ort") val location: String? = null,
-    @PropertyElement(name = "raum_nr") val roomNumber: String? = null,
-    @PropertyElement(name = "raum_nr_architekt") val roomNumberArchitect: String? = null,
-    @PropertyElement(name = "termin_betreff") val title: String? = null,
-    @PropertyElement(name = "lv_grp_nr") val lectureGroupId: String? = null,
-    @PropertyElement(name = "lv_grp_name") val lectureGroupName: String? = null
+    @PropertyElement(name = "ort", converter = NullableEscapedStringConverter::class) val location: String? = null,
+    @PropertyElement(name = "raum_nr", converter = NullableEscapedStringConverter::class) val roomNumber: String? = null,
+    @PropertyElement(name = "raum_nr_architekt", converter = NullableEscapedStringConverter::class) val roomNumberArchitect: String? = null,
+    @PropertyElement(name = "termin_betreff", converter = NullableEscapedStringConverter::class) val title: String? = null,
+    @PropertyElement(name = "lv_grp_nr", converter = NullableEscapedStringConverter::class) val lectureGroupId: String? = null,
+    @PropertyElement(name = "lv_grp_name", converter = NullableEscapedStringConverter::class) val lectureGroupName: String? = null
 )

--- a/app/src/main/java/de/tum/in/tumcampusapp/component/tumui/lectures/model/LectureDetails.kt
+++ b/app/src/main/java/de/tum/in/tumcampusapp/component/tumui/lectures/model/LectureDetails.kt
@@ -2,6 +2,8 @@ package de.tum.`in`.tumcampusapp.component.tumui.lectures.model
 
 import com.tickaroo.tikxml.annotation.PropertyElement
 import com.tickaroo.tikxml.annotation.Xml
+import de.tum.`in`.tumcampusapp.api.tumonline.converters.EscapedStringConverter
+import de.tum.`in`.tumcampusapp.api.tumonline.converters.NullableEscapedStringConverter
 
 /**
  * This class is dealing with the deserialization of the output of TUMOnline to
@@ -9,26 +11,26 @@ import com.tickaroo.tikxml.annotation.Xml
  */
 @Xml(name = "row")
 data class LectureDetails(
-    @PropertyElement(name = "dauer_info") val duration: String? = null,
-    @PropertyElement(name = "ersttermin") val firstAppointment: String? = null,
-    @PropertyElement(name = "haupt_unterrichtssprache") val mainLanguage: String? = null,
-    @PropertyElement(name = "lehrinhalt") val lectureContent: String? = null,
-    @PropertyElement(name = "lehrmethode") val teachingMethod: String? = null,
-    @PropertyElement(name = "lehrziel") val teachingTargets: String? = null,
-    @PropertyElement(name = "org_kennung_betreut") val chairTumId: String? = null,
-    @PropertyElement(name = "org_name_betreut") val chairName: String? = null,
-    @PropertyElement(name = "org_nr_betreut") val chairId: String? = null,
-    @PropertyElement(name = "semester") val semester: String? = null,
-    @PropertyElement(name = "semester_id") val semesterId: String? = null,
-    @PropertyElement(name = "semester_name") val semesterName: String? = null,
-    @PropertyElement(name = "sj_name") val semesterYears: String? = null,
-    @PropertyElement(name = "stp_lv_art_kurz") val shortLectureType: String? = null,
-    @PropertyElement(name = "stp_lv_art_name") val lectureType: String? = null,
-    @PropertyElement(name = "stp_lv_nr") val lectureId: String, // TODO: Rename variables
-    @PropertyElement(name = "stp_sp_nr") val stp_sp_nr: String,
-    @PropertyElement(name = "stp_sp_sst") val stp_sp_sst: String? = null,
-    @PropertyElement(name = "stp_sp_titel") val title: String,
-    @PropertyElement(name = "studienbehelfe") val examinationAids: String? = null,
-    @PropertyElement(name = "voraussetzung_lv") val lectureRequirements: String? = null,
-    @PropertyElement(name = "vortragende_mitwirkende") val lecturers: String? = null
+    @PropertyElement(name = "dauer_info", converter = NullableEscapedStringConverter::class) val duration: String? = null,
+    @PropertyElement(name = "ersttermin", converter = NullableEscapedStringConverter::class) val firstAppointment: String? = null,
+    @PropertyElement(name = "haupt_unterrichtssprache", converter = NullableEscapedStringConverter::class) val mainLanguage: String? = null,
+    @PropertyElement(name = "lehrinhalt", converter = NullableEscapedStringConverter::class) val lectureContent: String? = null,
+    @PropertyElement(name = "lehrmethode", converter = NullableEscapedStringConverter::class) val teachingMethod: String? = null,
+    @PropertyElement(name = "lehrziel", converter = NullableEscapedStringConverter::class) val teachingTargets: String? = null,
+    @PropertyElement(name = "org_kennung_betreut", converter = NullableEscapedStringConverter::class) val chairTumId: String? = null,
+    @PropertyElement(name = "org_name_betreut", converter = NullableEscapedStringConverter::class) val chairName: String? = null,
+    @PropertyElement(name = "org_nr_betreut", converter = NullableEscapedStringConverter::class) val chairId: String? = null,
+    @PropertyElement(name = "semester", converter = NullableEscapedStringConverter::class) val semester: String? = null,
+    @PropertyElement(name = "semester_id", converter = NullableEscapedStringConverter::class) val semesterId: String? = null,
+    @PropertyElement(name = "semester_name", converter = NullableEscapedStringConverter::class) val semesterName: String? = null,
+    @PropertyElement(name = "sj_name", converter = NullableEscapedStringConverter::class) val semesterYears: String? = null,
+    @PropertyElement(name = "stp_lv_art_kurz", converter = NullableEscapedStringConverter::class) val shortLectureType: String? = null,
+    @PropertyElement(name = "stp_lv_art_name", converter = NullableEscapedStringConverter::class) val lectureType: String? = null,
+    @PropertyElement(name = "stp_lv_nr", converter = EscapedStringConverter::class) val lectureId: String, // TODO: Rename variables
+    @PropertyElement(name = "stp_sp_nr", converter = EscapedStringConverter::class) val stp_sp_nr: String,
+    @PropertyElement(name = "stp_sp_sst", converter = NullableEscapedStringConverter::class) val stp_sp_sst: String? = null,
+    @PropertyElement(name = "stp_sp_titel", converter = EscapedStringConverter::class) val title: String,
+    @PropertyElement(name = "studienbehelfe", converter = NullableEscapedStringConverter::class) val examinationAids: String? = null,
+    @PropertyElement(name = "voraussetzung_lv", converter = NullableEscapedStringConverter::class) val lectureRequirements: String? = null,
+    @PropertyElement(name = "vortragende_mitwirkende", converter = NullableEscapedStringConverter::class) val lecturers: String? = null
 )


### PR DESCRIPTION
Parse html character escape sequences in lecture API responses into their respective characters.

## Issue

This fixes the following issue(s):

Html character escape sequences (ie. `&quot;` or `&amp;`) are sometimes present in lecture API responses and appear to the user instead of the represented characters (ie. `"` or `&`).

## Screenshot
![](https://i.jfoe.de/vR2l)
![](https://i.jfoe.de/Y1fi)

## Why this is useful for all students
This shows lecture information as it is shown on the web at `campus.tum.de`.
