### PR TITLE
Fixes existing tests crashing

### DIFF
--- a/app/src/main/java/de/tum/in/tumcampusapp/App.kt
+++ b/app/src/main/java/de/tum/in/tumcampusapp/App.kt
@@ -3,7 +3,9 @@ package de.tum.`in`.tumcampusapp
 import android.app.Application
 import android.os.StrictMode
 import androidx.appcompat.app.AppCompatDelegate
+import com.google.firebase.FirebaseApp
 import com.google.firebase.crashlytics.FirebaseCrashlytics
+import com.google.firebase.provider.FirebaseInitProvider
 import com.squareup.picasso.OkHttp3Downloader
 import com.squareup.picasso.Picasso
 import de.tum.`in`.tumcampusapp.component.notifications.NotificationUtils.setupNotificationChannels
@@ -68,7 +70,7 @@ open class App : Application() {
         }
     }
 
-    private fun initRxJavaErrorHandler() {
+    protected open fun initRxJavaErrorHandler() {
         RxJavaPlugins.setErrorHandler(FirebaseCrashlytics.getInstance()::recordException)
     }
 

--- a/app/src/main/java/de/tum/in/tumcampusapp/TestApp.kt
+++ b/app/src/main/java/de/tum/in/tumcampusapp/TestApp.kt
@@ -1,11 +1,19 @@
 package de.tum.`in`.tumcampusapp
 
 import android.annotation.SuppressLint
+import com.google.firebase.FirebaseApp
+import com.google.firebase.crashlytics.FirebaseCrashlytics
+import io.reactivex.plugins.RxJavaPlugins
 
 @SuppressLint("Registered")
 class TestApp : App() {
 
     override fun setupPicasso() {
         // nothing to do
+    }
+
+    override fun initRxJavaErrorHandler(){
+        FirebaseApp.initializeApp(applicationContext)
+        RxJavaPlugins.setErrorHandler(FirebaseCrashlytics.getInstance()::recordException)
     }
 }


### PR DESCRIPTION
## Issue

This fixes the following issue(s): Currently all of the tests that exist and are not ignored crash with the same error [see my comment on another issue.](https://github.com/TUM-Dev/Campus-Android/issues/1378#issuecomment-950571857). This means that even the code for which tests exist, can not be verified.

## Screenshot

### Current
![Failing_tests_tca](https://user-images.githubusercontent.com/9247500/138644998-2e2e8a94-e5c3-499f-8651-f05c6eedaefd.png)

### Fixed
![FirebaseApp_initialized](https://user-images.githubusercontent.com/9247500/140702537-4d36f034-9080-4d9f-8f9a-031e391f9281.png)

## Implementation
**FirebaseApp, which is normally initialized by FirebaseInitProvider *before Application.onCreate()* is not run in the test source set**. Thus, FirebaseApp needs to manually be initialized, to that ensure FirebaseCrashlytics works.

## Why this is useful for all students
Ensuring that the test suite is up and running prevents introducing new errors, makes it easier to work on TCA and increases usability for users.
