### PR TITLE
add di for roomfinder map

### DIFF
--- a/app/src/main/java/de/tum/in/tumcampusapp/component/tumui/roomfinder/RoomFinderDetailsActivity.kt
+++ b/app/src/main/java/de/tum/in/tumcampusapp/component/tumui/roomfinder/RoomFinderDetailsActivity.kt
@@ -55,6 +55,8 @@ class RoomFinderDetailsActivity : ActivityForLoadingInBackground<Void, String>(R
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
+        injector.roomFinderComponent().inject(this)
+
         imageFragment = ImageViewTouchFragment.newInstance()
         supportFragmentManager.beginTransaction()
                 .add(R.id.fragment_container, imageFragment)

--- a/app/src/main/java/de/tum/in/tumcampusapp/component/tumui/roomfinder/di/RoomFinderComponent.kt
+++ b/app/src/main/java/de/tum/in/tumcampusapp/component/tumui/roomfinder/di/RoomFinderComponent.kt
@@ -1,0 +1,10 @@
+package de.tum.`in`.tumcampusapp.component.tumui.roomfinder.di
+
+import de.tum.`in`.tumcampusapp.component.tumui.roomfinder.RoomFinderDetailsActivity
+
+import dagger.Subcomponent
+
+@Subcomponent()
+interface RoomFinderComponent {
+    fun inject(roomFinderDetailsActivity: RoomFinderDetailsActivity)
+}

--- a/app/src/main/java/de/tum/in/tumcampusapp/di/AppComponent.kt
+++ b/app/src/main/java/de/tum/in/tumcampusapp/di/AppComponent.kt
@@ -5,6 +5,7 @@ import dagger.BindsInstance
 import dagger.Component
 import de.tum.`in`.tumcampusapp.component.other.settings.SettingsFragment
 import de.tum.`in`.tumcampusapp.component.tumui.feedback.di.FeedbackComponent
+import de.tum.`in`.tumcampusapp.component.tumui.roomfinder.di.RoomFinderComponent
 import de.tum.`in`.tumcampusapp.component.ui.cafeteria.di.CafeteriaComponent
 import de.tum.`in`.tumcampusapp.component.ui.news.di.NewsComponent
 import de.tum.`in`.tumcampusapp.component.ui.onboarding.di.OnboardingComponent
@@ -28,6 +29,7 @@ interface AppComponent {
     fun newsComponent(): NewsComponent
     fun onboardingComponent(): OnboardingComponent.Factory
     fun ticketsComponent(): TicketsComponent.Builder
+    fun roomFinderComponent(): RoomFinderComponent
 
     fun inject(mainActivity: MainActivity)
     fun inject(mainFragment: MainFragment)


### PR DESCRIPTION
## Issue

This fixes the following issue(s):

The map view of the roomfinder showing an error and loading indefinitely when pressing retry. This is fixed by adding dependency injection to the `RoomFinderDetailsActivity` which allows calling the required apis.

## Screenshot
Not much to screenshot - it just kept loading.


## Why this is useful for all students
Now it is possible again to view the map of where searched rooms are located.
