### PR TITLE
Fix memory leak in BaseNavigationActivity

### DIFF
--- a/app/src/main/java/de/tum/in/tumcampusapp/component/other/generic/activity/BaseNavigationActivity.kt
+++ b/app/src/main/java/de/tum/in/tumcampusapp/component/other/generic/activity/BaseNavigationActivity.kt
@@ -101,6 +101,8 @@ class BaseNavigationActivity : BaseActivity(
         val drawerLayout = findViewById<DrawerLayout>(R.id.drawer_layout)
         val toolbar = findViewById<Toolbar>(R.id.toolbar)
 
+        drawerToggle?.let { drawerLayout.removeDrawerListener(it) }
+
         drawerToggle = object : ActionBarDrawerToggle(this, drawerLayout,
             toolbar, R.string.drawer_open, R.string.drawer_close) {}
 


### PR DESCRIPTION
## Issue

This fixes the following issue(s):
The `BaseNavigationActivity` did not unregister the previous `DrawerListener` when replacing the fragment and creating a new drawerToggle. This effectively leaked the entire View since then the `DrawerLayout` held a reference to the old drawerToggle which in turn references the `Toolbar` and all of it's parents.  

The simple solution is to deregister the `DrawerListener` when replacing the drawerToggle.

<details>
<summary>LeakCanary report</summary>

```
┬───
│ GC Root: System class
│
├─ leakcanary.internal.InternalLeakCanary class
│    Leaking: NO (BaseNavigationActivity↓ is not leaking and a class is never leaking)
│    ↓ static InternalLeakCanary.resumedActivity
├─ de.tum.in.tumcampusapp.component.other.generic.activity.BaseNavigationActivity instance
│    Leaking: NO (DrawerLayout↓ is not leaking and Activity#mDestroyed is false)
│    ↓ BaseNavigationActivity.drawerLayout$delegate
├─ kotlin.SynchronizedLazyImpl instance
│    Leaking: NO (DrawerLayout↓ is not leaking)
│    ↓ SynchronizedLazyImpl._value
├─ androidx.drawerlayout.widget.DrawerLayout instance
│    Leaking: NO (View attached)
│    mContext instance of de.tum.in.tumcampusapp.component.other.generic.activity.BaseNavigationActivity with mDestroyed = false
│    View.parent androidx.appcompat.widget.ContentFrameLayout attached as well
│    View#mParent is set
│    View#mAttachInfo is not null (view attached)
│    View.mID = R.id.drawer_layout
│    View.mWindowAttachCount = 1
│    ↓ DrawerLayout.mListeners
│                   ~~~~~~~~~~
├─ java.util.ArrayList instance
│    Leaking: UNKNOWN
│    ↓ ArrayList.elementData
│                ~~~~~~~~~~~
├─ java.lang.Object[] array
│    Leaking: UNKNOWN
│    ↓ Object[].[0]
│               ~~~
├─ de.tum.in.tumcampusapp.component.other.generic.activity.BaseNavigationActivity$initDrawerToggle$1 instance
│    Leaking: UNKNOWN
│    Anonymous subclass of androidx.appcompat.app.ActionBarDrawerToggle
│    ↓ BaseNavigationActivity$initDrawerToggle$1.mActivityImpl
│                                                ~~~~~~~~~~~~~
├─ androidx.appcompat.app.ActionBarDrawerToggle$ToolbarCompatDelegate instance
│    Leaking: UNKNOWN
│    ↓ ActionBarDrawerToggle$ToolbarCompatDelegate.mToolbar
│                                                  ~~~~~~~~
├─ androidx.appcompat.widget.Toolbar instance
│    Leaking: YES (View detached and has parent)
│    mContext instance of android.view.ContextThemeWrapper, wrapping activity de.tum.in.tumcampusapp.component.other.generic.activity.BaseNavigationActivity with mDestroyed = false
│    View#mParent is set
│    View#mAttachInfo is null (view detached)
│    View.mID = R.id.toolbar
│    View.mWindowAttachCount = 1
│    ↓ Toolbar.mParent
├─ com.google.android.material.appbar.AppBarLayout instance
│    Leaking: YES (Toolbar↑ is leaking and View detached and has parent)
│    mContext instance of de.tum.in.tumcampusapp.component.other.generic.activity.BaseNavigationActivity with mDestroyed = false
│    View#mParent is set
│    View#mAttachInfo is null (view detached)
│    View.mWindowAttachCount = 1
│    ↓ AppBarLayout.mParent
╰→ androidx.coordinatorlayout.widget.CoordinatorLayout instance
​     Leaking: YES (ObjectWatcher was watching this because de.tum.in.tumcampusapp.component.ui.overview.MainFragment received Fragment#onDestroyView() callback (references to its views should be cleared to prevent leaks))
​     key = 4f432243-e220-4112-81f3-bebc33475c36
​     watchDurationMillis = 14092
​     retainedDurationMillis = 9090
​     mContext instance of de.tum.in.tumcampusapp.component.other.generic.activity.BaseNavigationActivity with mDestroyed = false
​     View#mParent is null
​     View#mAttachInfo is null (view detached)
​     View.mWindowAttachCount = 1

METADATA

Build.VERSION.SDK_INT: 26
Build.MANUFACTURER: samsung
LeakCanary version: 2.4
App process name: de.tum.in.tumcampus
Analysis duration: 13245 ms
```

</details>

## Why this is useful for all students
Memory no longer leaks on every navigation.
