### PR TITLE
fix double url encoding and cleaner coord-api error handling

### DIFF
--- a/app/src/main/java/de/tum/in/tumcampusapp/api/app/TUMCabeClient.java
+++ b/app/src/main/java/de/tum/in/tumcampusapp/api/app/TUMCabeClient.java
@@ -295,7 +295,7 @@ public final class TUMCabeClient {
     }
 
     public Call<RoomFinderCoordinate> fetchRoomFinderCoordinates(String archId) {
-        return service.fetchCoordinates(ApiHelper.encodeUrl(archId));
+        return service.fetchCoordinates(archId);
     }
 
     @Nullable

--- a/app/src/main/java/de/tum/in/tumcampusapp/component/other/locations/LocationManager.kt
+++ b/app/src/main/java/de/tum/in/tumcampusapp/component/other/locations/LocationManager.kt
@@ -288,6 +288,10 @@ class LocationManager @Inject constructor(c: Context) {
     private fun fetchRoomGeo(archId: String): Geo? {
         return try {
             val coordinate = TUMCabeClient.getInstance(mContext).fetchCoordinates(archId)
+            if (coordinate.error.isNotEmpty()) {
+                Utils.log("Coordinate api error: " + coordinate.error)
+                return null
+            }
             coordinate?.let { convertRoomFinderCoordinateToGeo(it) }
         } catch (e: IOException) {
             Utils.log(e)

--- a/app/src/main/java/de/tum/in/tumcampusapp/component/tumui/roomfinder/model/RoomFinderCoordinate.kt
+++ b/app/src/main/java/de/tum/in/tumcampusapp/component/tumui/roomfinder/model/RoomFinderCoordinate.kt
@@ -3,5 +3,6 @@ package de.tum.`in`.tumcampusapp.component.tumui.roomfinder.model
 data class RoomFinderCoordinate(
     var utm_zone: String = "",
     var utm_easting: String = "",
-    var utm_northing: String = ""
+    var utm_northing: String = "",
+    var error: String = ""
 )


### PR DESCRIPTION
## Issue

This fixes the following issue(s):
1. double URL encoding:
	When calling the room-coordinate api the identifiers were url-encoded two times: once manually using `ApiHelper.encodeUrl()` and once automatically by retrofit. The result does not decode to the original anymore and the api returns an error.
Example: `02.09.014@5609` -> `01.06.020%405606` -> `01.06.020%25405606` 
This is fixed by eliminating the first, manual encoding.
2. room-coordinate api error handling
	When the api returns an error (with http code 200), it is now caught and logged, instead of trying to decode empty Strings.
	example:
	![](https://i.jfoe.de/EGzq)

