### PR TITLE
replace "by lazy" view references in BaseFragment

### DIFF
--- a/app/src/main/java/de/tum/in/tumcampusapp/component/other/generic/activity/ProgressActivity.kt
+++ b/app/src/main/java/de/tum/in/tumcampusapp/component/other/generic/activity/ProgressActivity.kt
@@ -53,7 +53,7 @@ abstract class ProgressActivity<T>(
     }
 
     private val errorLayout: LinearLayout by lazy {
-        findViewById<LinearLayout>(R.id.error_layout)
+        findViewById<LinearLayout>(R.id.layout_error)
     }
 
     private val errorIconImageView: ImageView by lazy {
@@ -73,7 +73,7 @@ abstract class ProgressActivity<T>(
     }
 
     private val progressLayout: FrameLayout by lazy {
-        findViewById<FrameLayout>(R.id.progress_layout)
+        findViewById<FrameLayout>(R.id.layout_progress)
     }
 
     private var registered: Boolean = false

--- a/app/src/main/java/de/tum/in/tumcampusapp/component/other/generic/fragment/BaseFragment.kt
+++ b/app/src/main/java/de/tum/in/tumcampusapp/component/other/generic/fragment/BaseFragment.kt
@@ -10,16 +10,11 @@ import android.view.View
 import android.view.ViewGroup
 import android.view.animation.Animation
 import android.view.animation.AnimationUtils
-import android.widget.FrameLayout
-import android.widget.ImageView
-import android.widget.LinearLayout
-import android.widget.TextView
 import androidx.annotation.LayoutRes
 import androidx.annotation.StringRes
 import androidx.appcompat.widget.Toolbar
 import androidx.fragment.app.Fragment
 import androidx.swiperefreshlayout.widget.SwipeRefreshLayout
-import com.google.android.material.button.MaterialButton
 import com.google.android.material.snackbar.Snackbar
 import de.tum.`in`.tumcampusapp.R
 import de.tum.`in`.tumcampusapp.api.tumonline.exception.InactiveTokenException
@@ -33,6 +28,7 @@ import de.tum.`in`.tumcampusapp.component.other.generic.viewstates.ErrorViewStat
 import de.tum.`in`.tumcampusapp.component.other.generic.viewstates.FailedTokenViewState
 import de.tum.`in`.tumcampusapp.component.other.generic.viewstates.NoInternetViewState
 import de.tum.`in`.tumcampusapp.component.other.generic.viewstates.UnknownErrorViewState
+import de.tum.`in`.tumcampusapp.databinding.LayoutAllErrorsBinding
 import de.tum.`in`.tumcampusapp.utils.NetUtils
 import de.tum.`in`.tumcampusapp.utils.Utils
 import de.tum.`in`.tumcampusapp.utils.setImageResourceOrHide
@@ -55,41 +51,13 @@ abstract class BaseFragment<T>(
     private val toolbar: Toolbar?
         get() = requireActivity().findViewById<Toolbar?>(R.id.toolbar)
 
-    private val contentView: ViewGroup by lazy {
-        requireActivity().findViewById<ViewGroup>(android.R.id.content).getChildAt(0) as ViewGroup
-    }
+    private val contentView: ViewGroup
+        get() = requireActivity().findViewById<ViewGroup>(android.R.id.content).getChildAt(0) as ViewGroup
 
-    protected val swipeRefreshLayout: SwipeRefreshLayout? by lazy {
-        requireActivity().findViewById<SwipeRefreshLayout?>(R.id.swipeRefreshLayout)
-    }
-
-    private val errorLayoutsContainer: FrameLayout by lazy {
-        requireActivity().findViewById<FrameLayout>(R.id.errors_layout)
-    }
-
-    private val errorLayout: LinearLayout by lazy {
-        requireActivity().findViewById<LinearLayout>(R.id.error_layout)
-    }
-
-    private val errorIconImageView: ImageView by lazy {
-        requireActivity().findViewById<ImageView>(R.id.iconImageView)
-    }
-
-    private val errorHeaderTextView: TextView by lazy {
-        errorLayout.findViewById<TextView>(R.id.headerTextView)
-    }
-
-    private val errorMessageTextView: TextView by lazy {
-        errorLayout.findViewById<TextView>(R.id.messageTextView)
-    }
-
-    private val errorButton: MaterialButton by lazy {
-        errorLayout.findViewById<MaterialButton>(R.id.button)
-    }
-
-    private val progressLayout: FrameLayout by lazy {
-        requireActivity().findViewById<FrameLayout>(R.id.progress_layout)
-    }
+    // Override in subclasses to access ViewBindings when applicable
+    protected open val swipeRefreshLayout: SwipeRefreshLayout? = null
+    protected open val layoutAllErrorsBinding: LayoutAllErrorsBinding
+        get() = throw NotImplementedError()
 
     private val baseActivity: BaseActivity
         get() = requireActivity() as BaseActivity
@@ -292,28 +260,30 @@ abstract class BaseFragment<T>(
 
     protected fun showContentLayout() {
         runOnUiThread {
-            errorLayout.visibility = View.GONE
+            layoutAllErrorsBinding.layoutError.errorLayout.visibility = View.GONE
         }
     }
 
     protected fun showErrorLayout() {
         runOnUiThread {
-            errorLayout.visibility = View.VISIBLE
+            layoutAllErrorsBinding.layoutError.errorLayout.visibility = View.VISIBLE
         }
     }
 
     private fun showError(viewState: ErrorViewState) {
         showLoadingEnded()
 
-        errorIconImageView.setImageResourceOrHide(viewState.iconResId)
-        errorHeaderTextView.setTextOrHide(viewState.headerResId)
-        errorMessageTextView.setTextOrHide(viewState.messageResId)
+        with(layoutAllErrorsBinding.layoutError) {
+            iconImageView.setImageResourceOrHide(viewState.iconResId)
+            headerTextView.setTextOrHide(viewState.headerResId)
+            messageTextView.setTextOrHide(viewState.messageResId)
 
-        errorButton.setTextOrHide(viewState.buttonTextResId)
-        errorButton.setOnClickListener { retryRequest() }
+            button.setTextOrHide(viewState.buttonTextResId)
+            button.setOnClickListener { retryRequest() }
 
-        errorLayoutsContainer.visibility = View.VISIBLE
-        errorLayout.visibility = View.VISIBLE
+            errorLayout.visibility = View.VISIBLE
+        }
+        layoutAllErrorsBinding.errorsLayout.visibility = View.VISIBLE
     }
 
     /**
@@ -356,9 +326,11 @@ abstract class BaseFragment<T>(
             return
         }
 
-        errorLayoutsContainer.visibility = View.VISIBLE
-        errorLayout.visibility = View.GONE
-        progressLayout.visibility = View.VISIBLE
+        with(layoutAllErrorsBinding) {
+            errorsLayout.visibility = View.VISIBLE
+            layoutError.errorLayout.visibility = View.GONE
+            layoutProgress.progressLayout.visibility = View.VISIBLE
+        }
     }
 
     /**
@@ -366,9 +338,11 @@ abstract class BaseFragment<T>(
      * and stopping the refreshing of [SwipeRefreshLayout]
      */
     protected fun showLoadingEnded() {
-        errorLayoutsContainer.visibility = View.GONE
-        progressLayout.visibility = View.GONE
-        errorLayout.visibility = View.GONE
+        with(layoutAllErrorsBinding) {
+            errorsLayout.visibility = View.GONE
+            layoutProgress.progressLayout.visibility = View.GONE
+            layoutError.errorLayout.visibility = View.GONE
+        }
         swipeRefreshLayout?.isRefreshing = false
     }
 

--- a/app/src/main/java/de/tum/in/tumcampusapp/component/tumui/calendar/CalendarFragment.kt
+++ b/app/src/main/java/de/tum/in/tumcampusapp/component/tumui/calendar/CalendarFragment.kt
@@ -75,6 +75,9 @@ class CalendarFragment : FragmentForAccessingTumOnline<EventsResponse>(
 
     private val binding by viewBinding(FragmentCalendarBinding::bind)
 
+    override val swipeRefreshLayout get() = binding.swipeRefreshLayout
+    override val layoutAllErrorsBinding get() = binding.layoutAllErrors
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setHasOptionsMenu(true)

--- a/app/src/main/java/de/tum/in/tumcampusapp/component/tumui/grades/GradesFragment.kt
+++ b/app/src/main/java/de/tum/in/tumcampusapp/component/tumui/grades/GradesFragment.kt
@@ -2,9 +2,7 @@ package de.tum.`in`.tumcampusapp.component.tumui.grades
 
 import android.animation.Animator
 import android.animation.AnimatorListenerAdapter
-import android.animation.LayoutTransition
 import android.graphics.Color
-import android.graphics.drawable.Animatable
 import android.os.Bundle
 import android.util.ArrayMap
 import android.view.Menu
@@ -13,7 +11,6 @@ import android.view.MenuItem
 import android.view.View
 import android.widget.AdapterView
 import android.widget.ArrayAdapter
-import android.widget.ImageView
 import androidx.core.content.ContextCompat
 import androidx.core.content.res.ResourcesCompat.getColor
 import com.github.mikephil.charting.components.Legend
@@ -56,6 +53,9 @@ class GradesFragment : FragmentForAccessingTumOnline<ExamList>(
 
     private val binding by viewBinding(FragmentGradesBinding::bind)
 
+    override val swipeRefreshLayout get() = binding.swipeRefreshLayout
+    override val layoutAllErrorsBinding get() = binding.layoutAllErrors
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setHasOptionsMenu(true)
@@ -81,7 +81,6 @@ class GradesFragment : FragmentForAccessingTumOnline<ExamList>(
             showListButton?.setOnClickListener { toggleInLandscape() }
             showChartButton?.setOnClickListener { toggleInLandscape() }
         }
-
 
         loadGrades(CacheControl.USE_CACHE)
 

--- a/app/src/main/java/de/tum/in/tumcampusapp/component/tumui/lectures/fragment/LecturesFragment.kt
+++ b/app/src/main/java/de/tum/in/tumcampusapp/component/tumui/lectures/fragment/LecturesFragment.kt
@@ -24,6 +24,9 @@ class LecturesFragment : FragmentForSearchingTumOnline<LecturesResponse>(
 
     private val binding by viewBinding(FragmentLecturesBinding::bind)
 
+    override val swipeRefreshLayout get() = binding.swipeRefreshLayout
+    override val layoutAllErrorsBinding get() = binding.layoutAllErrors
+
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 

--- a/app/src/main/java/de/tum/in/tumcampusapp/component/tumui/person/PersonSearchFragment.kt
+++ b/app/src/main/java/de/tum/in/tumcampusapp/component/tumui/person/PersonSearchFragment.kt
@@ -32,6 +32,9 @@ class PersonSearchFragment : FragmentForSearchingTumOnline<PersonList>(
 
     private val binding by viewBinding(FragmentPersonSearchBinding::bind)
 
+    override val swipeRefreshLayout get() = binding.swipeRefreshLayout
+    override val layoutAllErrorsBinding get() = binding.layoutAllErrors
+
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         recentsDao = TcaDb.getInstance(requireContext()).recentsDao()

--- a/app/src/main/java/de/tum/in/tumcampusapp/component/tumui/roomfinder/RoomFinderFragment.kt
+++ b/app/src/main/java/de/tum/in/tumcampusapp/component/tumui/roomfinder/RoomFinderFragment.kt
@@ -42,6 +42,8 @@ class RoomFinderFragment : FragmentForSearchingInBackground<List<RoomFinderRoom>
         }
 
     private val binding by viewBinding(FragmentRoomfinderBinding::bind)
+
+    override val layoutAllErrorsBinding get() = binding.layoutAllErrors
     
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)

--- a/app/src/main/java/de/tum/in/tumcampusapp/component/tumui/tutionfees/TuitionFeesFragment.kt
+++ b/app/src/main/java/de/tum/in/tumcampusapp/component/tumui/tutionfees/TuitionFeesFragment.kt
@@ -22,6 +22,9 @@ class TuitionFeesFragment : FragmentForAccessingTumOnline<TuitionList>(
 
     private val binding by viewBinding(FragmentTuitionFeesBinding::bind)
 
+    override val swipeRefreshLayout get() = binding.swipeRefreshLayout
+    override val layoutAllErrorsBinding get() = binding.layoutAllErrors
+
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 

--- a/app/src/main/java/de/tum/in/tumcampusapp/component/ui/barrierfree/BarrierFreeInfoFragment.kt
+++ b/app/src/main/java/de/tum/in/tumcampusapp/component/ui/barrierfree/BarrierFreeInfoFragment.kt
@@ -15,6 +15,8 @@ class BarrierFreeInfoFragment : BaseFragment<Unit>(
 
     private val binding by viewBinding(FragmentBarrierfreeInfoBinding::bind)
 
+    override val layoutAllErrorsBinding get() = binding.layoutAllErrors
+
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         binding.barrierFreeListView.setOnItemClickListener { _, _, position, _ ->

--- a/app/src/main/java/de/tum/in/tumcampusapp/component/ui/cafeteria/fragment/CafeteriaFragment.kt
+++ b/app/src/main/java/de/tum/in/tumcampusapp/component/ui/cafeteria/fragment/CafeteriaFragment.kt
@@ -64,6 +64,8 @@ class CafeteriaFragment : FragmentForDownloadingExternal(
 
     private val binding by viewBinding(FragmentCafeteriaBinding::bind)
 
+    override val layoutAllErrorsBinding get() = binding.layoutAllErrors
+
     override fun onAttach(context: Context) {
         super.onAttach(context)
         injector.cafeteriaComponent().inject(this)

--- a/app/src/main/java/de/tum/in/tumcampusapp/component/ui/chat/ChatRoomsFragment.kt
+++ b/app/src/main/java/de/tum/in/tumcampusapp/component/ui/chat/ChatRoomsFragment.kt
@@ -62,6 +62,9 @@ class ChatRoomsFragment : FragmentForAccessingTumOnline<LecturesResponse>(
 
     private val binding by viewBinding(FragmentChatRoomsBinding::bind)
 
+    override val swipeRefreshLayout get() = binding.swipeRefreshLayout
+    override val layoutAllErrorsBinding get() = binding.layoutAllErrors
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setHasOptionsMenu(true)

--- a/app/src/main/java/de/tum/in/tumcampusapp/component/ui/news/NewsFragment.kt
+++ b/app/src/main/java/de/tum/in/tumcampusapp/component/ui/news/NewsFragment.kt
@@ -40,6 +40,9 @@ class NewsFragment : FragmentForDownloadingExternal(
 
     private val binding by viewBinding(FragmentNewsBinding::bind)
 
+    override val swipeRefreshLayout get() = binding.swipeRefreshLayout
+    override val layoutAllErrorsBinding get() = binding.layoutAllErrors
+
     override fun onAttach(context: Context) {
         super.onAttach(context)
         injector.newsComponent().inject(this)

--- a/app/src/main/java/de/tum/in/tumcampusapp/component/ui/onboarding/CheckTokenFragment.kt
+++ b/app/src/main/java/de/tum/in/tumcampusapp/component/ui/onboarding/CheckTokenFragment.kt
@@ -47,6 +47,9 @@ class CheckTokenFragment : BaseFragment<Unit>(
 
     private val binding by viewBinding(FragmentCheckTokenBinding::bind)
 
+    override val swipeRefreshLayout get() = binding.swipeRefreshLayout
+    override val layoutAllErrorsBinding get() = binding.layoutAllErrors
+
     override fun onAttach(context: Context) {
         super.onAttach(context)
         onboardingComponent.inject(this)

--- a/app/src/main/java/de/tum/in/tumcampusapp/component/ui/onboarding/OnboardingExtrasFragment.kt
+++ b/app/src/main/java/de/tum/in/tumcampusapp/component/ui/onboarding/OnboardingExtrasFragment.kt
@@ -55,6 +55,9 @@ class OnboardingExtrasFragment : FragmentForLoadingInBackground<ChatMember>(
 
     private val binding by viewBinding(FragmentOnboardingExtrasBinding::bind)
 
+    override val swipeRefreshLayout get() = binding.swipeRefreshLayout
+    override val layoutAllErrorsBinding get() = binding.layoutAllErrors
+
     override fun onAttach(context: Context) {
         super.onAttach(context)
         onboardingComponent.inject(this)

--- a/app/src/main/java/de/tum/in/tumcampusapp/component/ui/onboarding/OnboardingStartFragment.kt
+++ b/app/src/main/java/de/tum/in/tumcampusapp/component/ui/onboarding/OnboardingStartFragment.kt
@@ -60,6 +60,9 @@ class OnboardingStartFragment : BaseFragment<Unit>(
 
     private val binding by viewBinding(FragmentOnboardingStartBinding::bind)
 
+    override val swipeRefreshLayout get() = binding.swipeRefreshLayout
+    override val layoutAllErrorsBinding get() = binding.layoutAllErrors
+
     override fun onAttach(context: Context) {
         super.onAttach(context)
         onboardingComponent.inject(this)

--- a/app/src/main/java/de/tum/in/tumcampusapp/component/ui/overview/MainFragment.kt
+++ b/app/src/main/java/de/tum/in/tumcampusapp/component/ui/overview/MainFragment.kt
@@ -7,9 +7,7 @@ import android.net.ConnectivityManager
 import android.net.Network
 import android.net.NetworkRequest
 import android.os.Bundle
-import android.view.LayoutInflater
 import android.view.View
-import android.view.ViewGroup
 import androidx.lifecycle.ViewModelProviders
 import androidx.recyclerview.widget.ItemTouchHelper
 import androidx.recyclerview.widget.LinearLayoutManager
@@ -62,6 +60,8 @@ class MainFragment : BaseFragment<Unit>(
 
     private val binding by viewBinding(FragmentMainBinding::bind)
 
+    override val swipeRefreshLayout get() = binding.swipeRefreshLayout
+
     @Inject
     lateinit var viewModelProvider: Provider<MainActivityViewModel>
     private val viewModel: MainActivityViewModel by lazy {
@@ -77,15 +77,14 @@ class MainFragment : BaseFragment<Unit>(
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
-        swipeRefreshLayout?.setOnRefreshListener(this)
-        swipeRefreshLayout?.isRefreshing = true
-        swipeRefreshLayout?.setColorSchemeResources(
-                R.color.color_primary,
-                R.color.tum_A100,
-                R.color.tum_A200)
-
-
         with(binding) {
+            swipeRefreshLayout.setOnRefreshListener(this@MainFragment)
+            swipeRefreshLayout.isRefreshing = true
+            swipeRefreshLayout.setColorSchemeResources(
+                    R.color.color_primary,
+                    R.color.tum_A100,
+                    R.color.tum_A200)
+
             registerForContextMenu(cardsRecyclerView)
 
             cardsRecyclerView.layoutManager = LinearLayoutManager(requireContext())

--- a/app/src/main/java/de/tum/in/tumcampusapp/component/ui/studyroom/StudyRoomsFragment.kt
+++ b/app/src/main/java/de/tum/in/tumcampusapp/component/ui/studyroom/StudyRoomsFragment.kt
@@ -27,6 +27,9 @@ class StudyRoomsFragment : FragmentForAccessingTumCabe<List<StudyRoomGroup>>(
 
     private val binding by viewBinding(FragmentStudyRoomsBinding::bind)
 
+    override val swipeRefreshLayout get() = binding.swipeRefreshLayout
+    override val layoutAllErrorsBinding get() = binding.layoutAllErrors
+
     // Drop-down navigation
     private val studyRoomGroupsSpinner: Spinner
         get() {

--- a/app/src/main/res/layout-land/fragment_grades.xml
+++ b/app/src/main/res/layout-land/fragment_grades.xml
@@ -29,6 +29,7 @@
     </com.google.android.material.appbar.AppBarLayout>
 
     <include
+        android:id="@+id/layout_all_errors"
         layout="@layout/layout_all_errors"
         android:layout_width="fill_parent"
         android:layout_height="fill_parent" />

--- a/app/src/main/res/layout/fragment_barrierfree_info.xml
+++ b/app/src/main/res/layout/fragment_barrierfree_info.xml
@@ -7,6 +7,7 @@
     <include layout="@layout/toolbar" />
 
     <include
+        android:id="@+id/layout_all_errors"
         layout="@layout/layout_all_errors"
         android:layout_width="match_parent"
         android:layout_height="match_parent" />

--- a/app/src/main/res/layout/fragment_cafeteria.xml
+++ b/app/src/main/res/layout/fragment_cafeteria.xml
@@ -34,6 +34,7 @@
         tools:ignore="UnusedAttribute">
 
         <include
+            android:id="@+id/layout_all_errors"
             layout="@layout/layout_all_errors"
             android:layout_width="fill_parent"
             android:layout_height="fill_parent" />

--- a/app/src/main/res/layout/fragment_calendar.xml
+++ b/app/src/main/res/layout/fragment_calendar.xml
@@ -18,7 +18,9 @@
             android:layout_height="match_parent"
             android:orientation="vertical">
 
-            <include layout="@layout/layout_all_errors" />
+            <include
+                android:id="@+id/layout_all_errors"
+                layout="@layout/layout_all_errors" />
 
             <FrameLayout
                 android:layout_width="match_parent"

--- a/app/src/main/res/layout/fragment_chat_rooms.xml
+++ b/app/src/main/res/layout/fragment_chat_rooms.xml
@@ -37,6 +37,7 @@
         android:orientation="vertical">
 
         <include
+            android:id="@+id/layout_all_errors"
             layout="@layout/layout_all_errors"
             android:layout_width="match_parent"
             android:layout_height="match_parent" />

--- a/app/src/main/res/layout/fragment_check_token.xml
+++ b/app/src/main/res/layout/fragment_check_token.xml
@@ -8,6 +8,7 @@
     <include layout="@layout/toolbar" />
 
     <include
+        android:id="@+id/layout_all_errors"
         layout="@layout/layout_all_errors"
         android:layout_width="match_parent"
         android:layout_height="match_parent" />

--- a/app/src/main/res/layout/fragment_grades.xml
+++ b/app/src/main/res/layout/fragment_grades.xml
@@ -29,6 +29,7 @@
     </com.google.android.material.appbar.AppBarLayout>
 
     <include
+        android:id="@+id/layout_all_errors"
         layout="@layout/layout_all_errors"
         android:layout_width="match_parent"
         android:layout_height="match_parent" />

--- a/app/src/main/res/layout/fragment_lectures.xml
+++ b/app/src/main/res/layout/fragment_lectures.xml
@@ -7,6 +7,7 @@
     <include layout="@layout/toolbar" />
 
     <include
+        android:id="@+id/layout_all_errors"
         layout="@layout/layout_all_errors"
         android:layout_width="fill_parent"
         android:layout_height="fill_parent" />

--- a/app/src/main/res/layout/fragment_news.xml
+++ b/app/src/main/res/layout/fragment_news.xml
@@ -8,6 +8,7 @@
     <include layout="@layout/toolbar"/>
 
     <include
+        android:id="@+id/layout_all_errors"
         layout="@layout/layout_all_errors"
         android:layout_width="match_parent"
         android:layout_height="match_parent" />

--- a/app/src/main/res/layout/fragment_onboarding_extras.xml
+++ b/app/src/main/res/layout/fragment_onboarding_extras.xml
@@ -7,6 +7,7 @@
     <include layout="@layout/toolbar" />
 
     <include
+        android:id="@+id/layout_all_errors"
         layout="@layout/layout_all_errors"
         android:layout_width="match_parent"
         android:layout_height="match_parent" />

--- a/app/src/main/res/layout/fragment_onboarding_start.xml
+++ b/app/src/main/res/layout/fragment_onboarding_start.xml
@@ -14,6 +14,7 @@
         android:layout_height="match_parent">
 
         <include
+            android:id="@+id/layout_all_errors"
             layout="@layout/layout_all_errors"
             android:layout_width="match_parent"
             android:layout_height="match_parent" />

--- a/app/src/main/res/layout/fragment_person_search.xml
+++ b/app/src/main/res/layout/fragment_person_search.xml
@@ -17,6 +17,7 @@
             android:layout_height="match_parent"
             android:orientation="vertical">
             <include
+                android:id="@+id/layout_all_errors"
                 layout="@layout/layout_all_errors"
                 android:layout_width="match_parent"
                 android:layout_height="match_parent" />

--- a/app/src/main/res/layout/fragment_roomfinder.xml
+++ b/app/src/main/res/layout/fragment_roomfinder.xml
@@ -7,6 +7,7 @@
     <include layout="@layout/toolbar" />
 
     <include
+        android:id="@+id/layout_all_errors"
         layout="@layout/layout_all_errors"
         android:layout_width="fill_parent"
         android:layout_height="fill_parent" />

--- a/app/src/main/res/layout/fragment_study_rooms.xml
+++ b/app/src/main/res/layout/fragment_study_rooms.xml
@@ -9,6 +9,7 @@
     <include layout="@layout/toolbar" />
 
     <include
+        android:id="@+id/layout_all_errors"
         layout="@layout/layout_all_errors"
         android:layout_width="match_parent"
         android:layout_height="match_parent" />

--- a/app/src/main/res/layout/fragment_tuition_fees.xml
+++ b/app/src/main/res/layout/fragment_tuition_fees.xml
@@ -9,6 +9,7 @@
     <include layout="@layout/toolbar" />
 
     <include
+        android:id="@+id/layout_all_errors"
         layout="@layout/layout_all_errors"
         android:layout_width="match_parent"
         android:layout_height="match_parent" />

--- a/app/src/main/res/layout/layout_all_errors.xml
+++ b/app/src/main/res/layout/layout_all_errors.xml
@@ -5,12 +5,14 @@
     android:visibility="gone">
 
     <include
+        android:id="@+id/layout_progress"
         layout="@layout/layout_progress"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:visibility="gone" />
 
     <include
+        android:id="@+id/layout_error"
         layout="@layout/layout_error"
         android:layout_width="match_parent"
         android:layout_height="match_parent"

--- a/app/src/test/java/de/tum/in/tumcampusapp/activities/KinoActivityTest.kt
+++ b/app/src/test/java/de/tum/in/tumcampusapp/activities/KinoActivityTest.kt
@@ -77,7 +77,7 @@ class KinoActivityTest {
         waitForUI()
         // For some reason the ui needs a while until it's been updated.
         Thread.sleep(100)
-        assertThat(kinoActivity!!.findViewById<View>(R.id.error_layout).visibility).isEqualTo(View.VISIBLE)
+        assertThat(kinoActivity!!.findViewById<View>(R.id.layout_error).visibility).isEqualTo(View.VISIBLE)
     }
 
     /**


### PR DESCRIPTION
## Issue

This fixes the following issue(s):
The `BaseFragment` initalizes all references to views by using the `by lazy {}`  construct. This works in activites but is problematic in  fragments because when replaced, their views are destroyed but the fragments themselves might be reused. `by lazy{}` is inadequate in this scenario because
1. all views are only initialized once, which might lead to all kinds of crazy behavior
2. (more overtly) `by lazy{}` captures references to the views which are not removed when the view is destroyed. This may leak the referenced views

To fix this I replaced these initializations with a safer albeit uglier method which allows for nulling the references in `onDestroyView()`. Example: 
```kotlin
private var _errorLayout: LinearLayout? = null
    get() = if(field == null) requireActivity().findViewById<LinearLayout>(R.id.error_layout).also { e -> field = e } else field

private val errorLayout: LinearLayout
    get() = _errorLayout!!
```

I am very open to an abstraction of this boilerplate or even an entirely different approach. For example, it would be easiest if every subclass only references and cleans up the views it actually interacts with.

<details>
<summary>Example of typical LeakCanary report</summary>

```lang-none
┬───
│ GC Root: System class
│
├─ leakcanary.internal.InternalLeakCanary class
│    Leaking: NO (BaseNavigationActivity↓ is not leaking and a class is never leaking)
│    ↓ static InternalLeakCanary.resumedActivity
├─ de.tum.in.tumcampusapp.component.other.generic.activity.BaseNavigationActivity instance
│    Leaking: NO (MainFragment↓ is not leaking and Activity#mDestroyed is false)
│    ↓ BaseNavigationActivity.mFragments
├─ androidx.fragment.app.FragmentController instance
│    Leaking: NO (MainFragment↓ is not leaking)
│    ↓ FragmentController.mHost
├─ androidx.fragment.app.FragmentActivity$HostCallbacks instance
│    Leaking: NO (MainFragment↓ is not leaking)
│    ↓ FragmentActivity$HostCallbacks.mFragmentManager
├─ androidx.fragment.app.FragmentManagerImpl instance
│    Leaking: NO (MainFragment↓ is not leaking)
│    ↓ FragmentManagerImpl.mFragmentStore
├─ androidx.fragment.app.FragmentStore instance
│    Leaking: NO (MainFragment↓ is not leaking)
│    ↓ FragmentStore.mActive
├─ java.util.HashMap instance
│    Leaking: NO (MainFragment↓ is not leaking)
│    ↓ HashMap.table
├─ java.util.HashMap$Node[] array
│    Leaking: NO (MainFragment↓ is not leaking)
│    ↓ HashMap$Node[].[1]
├─ java.util.HashMap$Node instance
│    Leaking: NO (MainFragment↓ is not leaking)
│    ↓ HashMap$Node.value
├─ androidx.fragment.app.FragmentStateManager instance
│    Leaking: NO (MainFragment↓ is not leaking)
│    ↓ FragmentStateManager.mFragment
├─ de.tum.in.tumcampusapp.component.ui.overview.MainFragment instance
│    Leaking: NO (Fragment#mFragmentManager is not null)
│    ↓ MainFragment.swipeRefreshLayout$delegate
│                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~
├─ kotlin.SynchronizedLazyImpl instance
│    Leaking: UNKNOWN
│    ↓ SynchronizedLazyImpl._value
│                           ~~~~~~
├─ androidx.swiperefreshlayout.widget.SwipeRefreshLayout instance
│    Leaking: YES (View detached and has parent)
│    mContext instance of de.tum.in.tumcampusapp.component.other.generic.activity.BaseNavigationActivity with mDestroyed = false
│    View#mParent is set
│    View#mAttachInfo is null (view detached)
│    View.mID = R.id.swipeRefreshLayout
│    View.mWindowAttachCount = 1
│    ↓ SwipeRefreshLayout.mParent
╰→ androidx.coordinatorlayout.widget.CoordinatorLayout instance
​     Leaking: YES (ObjectWatcher was watching this because de.tum.in.tumcampusapp.component.ui.overview.MainFragment received Fragment#onDestroyView() callback (references to its views should be cleared to prevent leaks))
​     key = c13eac11-cb25-4c63-8cb7-29be74ba35f8
​     watchDurationMillis = 22128
​     retainedDurationMillis = 17127
​     mContext instance of de.tum.in.tumcampusapp.component.other.generic.activity.BaseNavigationActivity with mDestroyed = false
​     View#mParent is null
​     View#mAttachInfo is null (view detached)
​     View.mWindowAttachCount = 1

METADATA

Build.VERSION.SDK_INT: 26
Build.MANUFACTURER: samsung
LeakCanary version: 2.4
App process name: de.tum.in.tumcampus
Analysis duration: 10673 ms
```
</details>