### PR TITLE
Issue/1416 migrate other to viewbinding

### DIFF
--- a/app/src/main/java/de/tum/in/tumcampusapp/component/other/generic/ImageViewTouchFragment.kt
+++ b/app/src/main/java/de/tum/in/tumcampusapp/component/other/generic/ImageViewTouchFragment.kt
@@ -9,11 +9,14 @@ import androidx.core.content.ContextCompat
 import androidx.fragment.app.Fragment
 import com.squareup.picasso.Callback
 import com.squareup.picasso.Picasso
+import com.zhuinden.fragmentviewbindingdelegatekt.viewBinding
 import de.tum.`in`.tumcampusapp.R
+import de.tum.`in`.tumcampusapp.databinding.FragmentImageViewTouchBinding
 import de.tum.`in`.tumcampusapp.utils.Utils
-import kotlinx.android.synthetic.main.fragment_image_view_touch.*
 
 class ImageViewTouchFragment : Fragment() {
+
+    private val binding by viewBinding(FragmentImageViewTouchBinding::bind)
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? =
         inflater.inflate(R.layout.fragment_image_view_touch, container, false)
@@ -27,7 +30,7 @@ class ImageViewTouchFragment : Fragment() {
         Picasso.get()
                 .load(url)
                 .placeholder(icon!!)
-                .into(photoView, object : Callback {
+                .into(binding.photoView, object : Callback {
                     override fun onSuccess() {
                         // Left empty on purpose
                     }

--- a/app/src/main/java/de/tum/in/tumcampusapp/component/other/generic/activity/BaseActivity.kt
+++ b/app/src/main/java/de/tum/in/tumcampusapp/component/other/generic/activity/BaseActivity.kt
@@ -2,16 +2,16 @@ package de.tum.`in`.tumcampusapp.component.other.generic.activity
 
 import android.content.Context
 import android.os.Bundle
-import android.preference.PreferenceManager
 import android.view.MenuItem
 import androidx.annotation.LayoutRes
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.app.NavUtils
 import de.tum.`in`.tumcampusapp.di.AppComponent
 import de.tum.`in`.tumcampusapp.di.app
-import kotlinx.android.synthetic.main.toolbar.toolbar
 import java.util.Locale
 import android.content.pm.PackageManager
+import androidx.appcompat.widget.Toolbar
+import androidx.preference.PreferenceManager
 import de.tum.`in`.tumcampusapp.R
 
 abstract class BaseActivity(
@@ -23,6 +23,8 @@ abstract class BaseActivity(
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(layoutId)
+
+        val toolbar = findViewById<Toolbar>(R.id.toolbar)
 
         // TODO Refactor
         if (this !is BaseNavigationActivity) {

--- a/app/src/main/java/de/tum/in/tumcampusapp/component/other/settings/SettingsFragment.kt
+++ b/app/src/main/java/de/tum/in/tumcampusapp/component/other/settings/SettingsFragment.kt
@@ -40,7 +40,6 @@ import io.reactivex.Single
 import io.reactivex.android.schedulers.AndroidSchedulers
 import io.reactivex.disposables.CompositeDisposable
 import io.reactivex.schedulers.Schedulers
-import kotlinx.android.synthetic.main.activity_setup_eduroam.*
 import org.jetbrains.anko.defaultSharedPreferences
 import org.jetbrains.anko.notificationManager
 import java.util.concurrent.ExecutionException


### PR DESCRIPTION
## Issue

This fixes the following issue(s): fixes #1416 

## Why this is useful for all students
Having a working app that can easily be maintained and expanded upon using the newest android features will improve the experience for users and developers alike.

## Progress

### component.other
- [x] `settings`
- [x] `generic`

This is the last part of the 3 PRs for migrating the project to view bindings. See #1417  and #1419  for the other PRs.