### PR TITLE
Add FLAG_IMMUTABLE to remaining PendingIntents

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -144,6 +144,8 @@ dependencies {
     implementation 'androidx.core:core-ktx:1.7.0'
     // Note: upgrading this and or androidx.appcompat:appcompat will break the toolbar
     implementation 'androidx.fragment:fragment-ktx:1.2.5'
+    // Note: fix for internal androidx libraries using outdated WorkManager causing a crash
+    implementation "androidx.work:work-runtime-ktx:2.7.1"
 
     // RxJava
     implementation 'io.reactivex.rxjava2:rxandroid:2.1.1'

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -17,7 +17,7 @@ apply from: '../gradle/scripts/checkstyle.gradle'
 apply from: '../gradle/scripts/testLogging.gradle'
 
 android {
-    compileSdkVersion 31
+    compileSdkVersion 32
     buildTypes {
         all {
             proguardFiles(file('../proguard').listFiles())
@@ -179,7 +179,7 @@ dependencies {
     kapt 'com.google.dagger:dagger-compiler:2.28.3'
 
     // LeakCanary
-    debugImplementation 'com.squareup.leakcanary:leakcanary-android:2.4'
+    debugImplementation 'com.squareup.leakcanary:leakcanary-android:2.9.1'
 
     // DebugDatabase
     debugImplementation 'com.amitshekhar.android:debug-db:1.0.6'

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -6,6 +6,7 @@
     tools:ignore="UnusedAttribute">
     <!-- Standard access rights -->
     <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.SCHEDULE_EXACT_ALARM" />
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" /> <!-- For google calendar synchronisation -->
     <uses-permission android:name="android.permission.READ_CALENDAR" />
     <uses-permission android:name="android.permission.WRITE_CALENDAR" /> <!-- To add searched person to contact list -->

--- a/app/src/main/java/de/tum/in/tumcampusapp/component/notifications/NotificationScheduler.kt
+++ b/app/src/main/java/de/tum/in/tumcampusapp/component/notifications/NotificationScheduler.kt
@@ -156,7 +156,7 @@ class NotificationScheduler @Inject constructor(private val context: Context) {
             putExtra(Const.KEY_NOTIFICATION, futureNotification.notification)
         }
         return PendingIntent.getBroadcast(context,
-                futureNotification.id, intent, PendingIntent.FLAG_CANCEL_CURRENT)
+                futureNotification.id, intent, PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_CANCEL_CURRENT)
     }
 
     /**
@@ -171,7 +171,7 @@ class NotificationScheduler @Inject constructor(private val context: Context) {
         val intent = Intent(context, NotificationAlarmReceiver::class.java).apply {
             putExtra(Const.KEY_NOTIFICATION_TYPE_ID, type.id)
         }
-        return PendingIntent.getBroadcast(context, type.id, intent, PendingIntent.FLAG_CANCEL_CURRENT)
+        return PendingIntent.getBroadcast(context, type.id, intent, PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_CANCEL_CURRENT)
     }
 
     companion object {

--- a/app/src/main/java/de/tum/in/tumcampusapp/component/other/general/UpdatePushNotification.kt
+++ b/app/src/main/java/de/tum/in/tumcampusapp/component/other/general/UpdatePushNotification.kt
@@ -55,7 +55,7 @@ class UpdatePushNotification(
 
             val sound = Uri.parse("android.resource://${appContext.packageName}/${R.raw.message}")
             val alarm = Intent(appContext, MainActivity::class.java)
-            val pending = PendingIntent.getActivity(appContext, 0, alarm, PendingIntent.FLAG_UPDATE_CURRENT)
+            val pending = PendingIntent.getActivity(appContext, 0, alarm, PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_UPDATE_CURRENT)
 
             val description = if (info.description.isNotEmpty()) {
                 info.description

--- a/app/src/main/java/de/tum/in/tumcampusapp/component/tumui/calendar/widget/TimetableWidget.kt
+++ b/app/src/main/java/de/tum/in/tumcampusapp/component/tumui/calendar/widget/TimetableWidget.kt
@@ -30,7 +30,7 @@ class TimetableWidget : AppWidgetProvider() {
     override fun onDisabled(context: Context) {
         // Cancel alarm as the last widget has been removed
         val intent = Intent(context, TimetableWidget::class.java)
-        val sender = PendingIntent.getBroadcast(context, 0, intent, 0)
+        val sender = PendingIntent.getBroadcast(context, 0, intent, PendingIntent.FLAG_IMMUTABLE)
         val alarmManager = context.getSystemService(Context.ALARM_SERVICE) as AlarmManager?
         if (alarmManager != null) {
             alarmManager.cancel(sender)
@@ -66,7 +66,7 @@ class TimetableWidget : AppWidgetProvider() {
 
             val intent = Intent(context, TimetableWidget::class.java)
             intent.action = BROADCAST_UPDATE_TIMETABLE_WIDGETS
-            val pi = PendingIntent.getBroadcast(context, 0, intent, 0)
+            val pi = PendingIntent.getBroadcast(context, 0, intent, PendingIntent.FLAG_IMMUTABLE)
 
             val am = context.getSystemService(Context.ALARM_SERVICE) as AlarmManager?
             if (am != null) {
@@ -113,20 +113,20 @@ class TimetableWidget : AppWidgetProvider() {
             val configIntent = Intent(context, TimetableWidgetConfigureActivity::class.java)
             configIntent.putExtra(AppWidgetManager.EXTRA_APPWIDGET_ID, appWidgetId)
             val pendingConfigIntent = PendingIntent.getActivity(
-                    context, appWidgetId, configIntent, PendingIntent.FLAG_UPDATE_CURRENT)
+                    context, appWidgetId, configIntent, PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_UPDATE_CURRENT)
             remoteViews.setOnClickPendingIntent(R.id.timetable_widget_setting, pendingConfigIntent)
 
             // Set up the calendar activity listeners
             val calendarIntent = Intent(context, CalendarActivity::class.java)
             val pendingCalendarIntent = PendingIntent.getActivity(
-                    context, appWidgetId, calendarIntent, PendingIntent.FLAG_UPDATE_CURRENT)
+                    context, appWidgetId, calendarIntent, PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_UPDATE_CURRENT)
             remoteViews.setOnClickPendingIntent(R.id.timetable_widget_header, pendingCalendarIntent)
 
             // Set up the calendar intent used when the user taps an event
             val eventIntent = Intent(context, CalendarActivity::class.java)
             eventIntent.putExtra(AppWidgetManager.EXTRA_APPWIDGET_ID, appWidgetId)
             val eventPendingIntent = PendingIntent.getActivity(
-                    context, appWidgetId, eventIntent, PendingIntent.FLAG_UPDATE_CURRENT)
+                    context, appWidgetId, eventIntent, PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_UPDATE_CURRENT)
             remoteViews.setPendingIntentTemplate(R.id.timetable_widget_listview, eventPendingIntent)
 
             // Set up the intent that starts the TimetableWidgetService, which will

--- a/app/src/main/java/de/tum/in/tumcampusapp/component/tumui/grades/GradesNotificationProvider.kt
+++ b/app/src/main/java/de/tum/in/tumcampusapp/component/tumui/grades/GradesNotificationProvider.kt
@@ -32,11 +32,11 @@ class GradesNotificationProvider(
                 R.plurals.new_grades_format_string, size, size, formattedNewGrades)
 
         val intent = GradesActivity.newIntent(context)
-        val pendingIntent = PendingIntent.getActivity(context, 0, intent, FLAG_UPDATE_CURRENT)
+        val pendingIntent = PendingIntent.getActivity(context, 0, intent, PendingIntent.FLAG_IMMUTABLE or FLAG_UPDATE_CURRENT)
 
         val deleteIntent = GradeNotificationDeleteReceiver.newIntent(context, newGrades)
         val deletePendingIntent = PendingIntent.getBroadcast(
-                context, DELETE_REQUEST_CODE, deleteIntent, PendingIntent.FLAG_UPDATE_CURRENT)
+                context, DELETE_REQUEST_CODE, deleteIntent, PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_UPDATE_CURRENT)
 
         val notification = getNotificationBuilder()
                 .setContentTitle(title)

--- a/app/src/main/java/de/tum/in/tumcampusapp/component/ui/cafeteria/CafeteriaNotificationProvider.kt
+++ b/app/src/main/java/de/tum/in/tumcampusapp/component/ui/cafeteria/CafeteriaNotificationProvider.kt
@@ -59,7 +59,7 @@ class CafeteriaNotificationProvider(context: Context) : NotificationProvider(con
         }
 
         val pendingIntent = PendingIntent.getActivity(
-                context, 0, intent, PendingIntent.FLAG_UPDATE_CURRENT)
+                context, 0, intent, PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_UPDATE_CURRENT)
 
         val summaryNotification = getNotificationBuilder()
                 .setContentTitle(title)

--- a/app/src/main/java/de/tum/in/tumcampusapp/component/ui/news/NewsNotificationProvider.kt
+++ b/app/src/main/java/de/tum/in/tumcampusapp/component/ui/news/NewsNotificationProvider.kt
@@ -34,7 +34,7 @@ class NewsNotificationProvider(
 
         val intent = Intent(context, NewsActivity::class.java)
         val pendingIntent = PendingIntent.getActivity(
-                context, 0, intent, PendingIntent.FLAG_UPDATE_CURRENT)
+                context, 0, intent, PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_UPDATE_CURRENT)
 
         val notification = getNotificationBuilder()
                 .setContentTitle(summaryTitle)

--- a/app/src/main/java/de/tum/in/tumcampusapp/component/ui/transportation/TransportNotificationProvider.kt
+++ b/app/src/main/java/de/tum/in/tumcampusapp/component/ui/transportation/TransportNotificationProvider.kt
@@ -35,7 +35,7 @@ class TransportNotificationProvider(context: Context) : NotificationProvider(con
 
         val intent = station.getIntent(context)
         val pendingIntent = PendingIntent.getActivity(
-                context, 0, intent, PendingIntent.FLAG_UPDATE_CURRENT)
+                context, 0, intent, PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_UPDATE_CURRENT)
 
         val notification = getNotificationBuilder()
                 .setContentTitle(title)

--- a/app/src/main/java/de/tum/in/tumcampusapp/component/ui/transportation/widget/MVVWidget.kt
+++ b/app/src/main/java/de/tum/in/tumcampusapp/component/ui/transportation/widget/MVVWidget.kt
@@ -56,7 +56,7 @@ class MVVWidget : AppWidgetProvider() {
         }
 
         val intent = Intent(context, MVVWidget::class.java)
-        val sender = PendingIntent.getBroadcast(context, 0, intent, 0)
+        val sender = PendingIntent.getBroadcast(context, 0, intent, PendingIntent.FLAG_IMMUTABLE)
         val alarmManager = context.alarmManager
         alarmManager.cancel(sender)
         if (autoReload) {
@@ -114,7 +114,7 @@ class MVVWidget : AppWidgetProvider() {
             putExtra(AppWidgetManager.EXTRA_APPWIDGET_ID, appWidgetId)
         }
         val pendingIntent = PendingIntent.getActivity(
-                context, appWidgetId, configIntent, PendingIntent.FLAG_UPDATE_CURRENT)
+                context, appWidgetId, configIntent, PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_UPDATE_CURRENT)
         remoteViews.setOnClickPendingIntent(R.id.mvv_widget_setting_button, pendingIntent)
 
         // Set up the reload functionality

--- a/app/src/main/java/de/tum/in/tumcampusapp/service/GeofencingRegistrationService.kt
+++ b/app/src/main/java/de/tum/in/tumcampusapp/service/GeofencingRegistrationService.kt
@@ -45,7 +45,7 @@ class GeofencingRegistrationService : JobIntentService() {
         val request = intent.getParcelableExtra<GeofencingRequest>(Const.ADD_GEOFENCE_EXTRA) ?: return
         val geofenceIntent = Intent(this, GeofencingUpdateReceiver::class.java)
         val geofencePendingIntent = PendingIntent.getBroadcast(
-                this, 0, geofenceIntent, PendingIntent.FLAG_UPDATE_CURRENT)
+                this, 0, geofenceIntent, PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_UPDATE_CURRENT)
 
         locationClient.addGeofences(request, geofencePendingIntent)
         Utils.log("Registered new Geofence")

--- a/app/src/main/java/de/tum/in/tumcampusapp/service/ScanResultsAvailableReceiver.kt
+++ b/app/src/main/java/de/tum/in/tumcampusapp/service/ScanResultsAvailableReceiver.kt
@@ -102,8 +102,8 @@ class ScanResultsAvailableReceiver : BroadcastReceiver() {
             val setupIntent = Intent(context, SetupEduroamActivity::class.java)
             val hideIntent = Intent(context, NeverShowAgainService::class.java)
 
-            val setupPendingIntent = PendingIntent.getActivity(context, 0, setupIntent, PendingIntent.FLAG_UPDATE_CURRENT)
-            val hidePendingIntent = PendingIntent.getService(context, 0, hideIntent, PendingIntent.FLAG_UPDATE_CURRENT)
+            val setupPendingIntent = PendingIntent.getActivity(context, 0, setupIntent, PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_UPDATE_CURRENT)
+            val hidePendingIntent = PendingIntent.getService(context, 0, hideIntent, PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_UPDATE_CURRENT)
 
             // Create FcmNotification using NotificationCompat.Builder
             val notification = NotificationCompat.Builder(context, Const.NOTIFICATION_CHANNEL_EDUROAM)

--- a/app/src/main/java/de/tum/in/tumcampusapp/service/SilenceService.kt
+++ b/app/src/main/java/de/tum/in/tumcampusapp/service/SilenceService.kt
@@ -68,7 +68,7 @@ class SilenceService : JobIntentService() {
 
         val alarmManager = this.getSystemService(Context.ALARM_SERVICE) as AlarmManager
         val newIntent = Intent(this, SilenceService::class.java)
-        val pendingIntent = PendingIntent.getService(this, 0, newIntent, PendingIntent.FLAG_UPDATE_CURRENT)
+        val pendingIntent = PendingIntent.getService(this, 0, newIntent, PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_UPDATE_CURRENT)
 
         val startTime = System.currentTimeMillis()
         var waitDuration = CHECK_INTERVAL.toLong()


### PR DESCRIPTION
Fixes #1427 and extends #1428 

All remaining instantiations of `PendingIntent` in the project have `FLAG_IMMUTABLE` added. Additionally `work-runtime-ktx` is added as a direct dependency as without it some androidx libraries internally rely on an outdated `WorkManager` which created `PendingIntent`s without `FLAG_IMMUTABLE` added yet.

If any of the `PendingIntent`s turn out to have to be mutable (which I haven't noticed) the flag would have to be replaced. But since without this change the call would lead to a crash in any case that should not be a hindrance.

