### PR TITLE
Switch to up-to-date fork of stickylistheaders

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -166,7 +166,7 @@ dependencies {
     implementation 'com.squareup.okio:okio:2.10.0'
 
     // UI
-    implementation 'se.emilsjolander:stickylistheaders:2.7.0'
+    implementation 'com.github.mtotschnig:StickyListHeaders:2.8.0'
     implementation 'com.github.chrisbanes:PhotoView:2.3.0'
     implementation 'me.dm7.barcodescanner:zxing:1.9.13'
     implementation 'com.journeyapps:zxing-android-embedded:3.6.0'


### PR DESCRIPTION
## Issue

This fixes the following issue(s): #1432 

## Why this is useful for all students

Should fix those crashes for other users of Android O. (I have no clue how widespread this issue is or whether it's only happening on my phone ......)

------
I'm unsure about possible regressions. I've used the app with the patched version of stickylistheaders for a couple of days now and it seems to be working well.
