### PR TITLE
Fix for issue #1421 MVV Widget TUM don't work

### DIFF
--- a/app/src/main/java/de/tum/in/tumcampusapp/component/ui/transportation/widget/MVVWidget.kt
+++ b/app/src/main/java/de/tum/in/tumcampusapp/component/ui/transportation/widget/MVVWidget.kt
@@ -123,7 +123,7 @@ class MVVWidget : AppWidgetProvider() {
             putExtra(AppWidgetManager.EXTRA_APPWIDGET_ID, appWidgetId)
         }
         val pendingReloadIntent = PendingIntent.getBroadcast(
-                context, appWidgetId, reloadIntent, PendingIntent.FLAG_UPDATE_CURRENT)
+                context, appWidgetId, reloadIntent, PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_UPDATE_CURRENT)
         remoteViews.setOnClickPendingIntent(R.id.mvv_widget_reload_button, pendingReloadIntent)
 
         val isAutoReload = widgetDepartures.autoReload

--- a/app/src/main/java/de/tum/in/tumcampusapp/component/ui/transportation/widget/MVVWidget.kt
+++ b/app/src/main/java/de/tum/in/tumcampusapp/component/ui/transportation/widget/MVVWidget.kt
@@ -161,6 +161,13 @@ class MVVWidget : AppWidgetProvider() {
                     updateAppWidget(context, AppWidgetManager.getInstance(context), appWidgetId, true)
                 }
             }
+            MVV_WIDGET_RELOAD_AFTER_CONFIG_CHANGES -> {
+                val appWidgetId = intent.getIntExtra(AppWidgetManager.EXTRA_APPWIDGET_ID, -1)
+                if (appWidgetId >= 0) {
+                    updateAppWidget(context, AppWidgetManager.getInstance(context), appWidgetId, true)
+                }
+                setAlarm(context)
+            }
         }
         super.onReceive(context, intent)
     }
@@ -170,6 +177,7 @@ class MVVWidget : AppWidgetProvider() {
         private const val BROADCAST_RELOAD_ALL_ALARM = "de.tum.in.newtumcampus.intent.action.BROADCAST_MVV_WIDGET_RELOAD_ALL_ALARM"
         private const val BROADCAST_RELOAD_ALL = "de.tum.in.newtumcampus.intent.action.BROADCAST_MVV_WIDGET_RELOAD_ALL"
         internal const val MVV_WIDGET_FORCE_RELOAD = "de.tum.in.newtumcampus.intent.action.MVV_WIDGET_FORCE_RELOAD"
+        internal const val MVV_WIDGET_RELOAD_AFTER_CONFIG_CHANGES = "de.tum.in.newtumcampus.intent.action.MVV_WIDGET_RELOAD_AFTER_CONFIG_CHANGES"
 
         const val UPDATE_ALARM_DELAY = 60 * 1000
         const val UPDATE_TRIGGER_DELAY = 20 * 1000

--- a/app/src/main/java/de/tum/in/tumcampusapp/component/ui/transportation/widget/MVVWidgetConfigureActivity.kt
+++ b/app/src/main/java/de/tum/in/tumcampusapp/component/ui/transportation/widget/MVVWidgetConfigureActivity.kt
@@ -149,7 +149,7 @@ class MVVWidgetConfigureActivity : ActivityForSearching<Unit>(
 
         // update widget
         val reloadIntent = Intent(this, MVVWidget::class.java)
-        reloadIntent.action = MVVWidget.MVV_WIDGET_FORCE_RELOAD
+        reloadIntent.action = MVVWidget.MVV_WIDGET_RELOAD_AFTER_CONFIG_CHANGES
         reloadIntent.putExtra(EXTRA_APPWIDGET_ID, appWidgetId)
         sendBroadcast(reloadIntent)
 

--- a/app/src/main/res/layout/activity_mvv_widget_configure.xml
+++ b/app/src/main/res/layout/activity_mvv_widget_configure.xml
@@ -5,9 +5,7 @@
     android:layout_height="match_parent">
 
     <!-- The toolbar aka SupportActionBar -->
-    <include
-        android:id="@+id/toolbar"
-        layout="@layout/toolbar" />
+    <include layout="@layout/toolbar" />
 
     <LinearLayout
         android:layout_width="fill_parent"
@@ -35,7 +33,7 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_alignParentBottom="true"
-        android:background="@color/card_pressed"
+        android:background="@color/secondary_window_background"
         android:elevation="10dp"
         android:paddingStart="20dp"
         android:paddingLeft="20dp"
@@ -68,7 +66,9 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_alignParentEnd="true"
-            android:layout_centerVertical="true" />
+            android:layout_centerVertical="true"
+            android:minHeight="48dp"
+            android:minWidth="48dp" />
 
     </RelativeLayout>
 


### PR DESCRIPTION
## Issue

This fixes the following issue(s): #1421

## Description

There were two problems with the widget:
- in API 31 FLAG_UPDATE_CURRENT requires also FLAG_IMMUTABLE or FLAG_MUTABLE, so I add it
- there was a problem with the unnecessary id for toolbar in the mvv widget layout. Because of that, the toolbar was mapped to AppBar which was throwing an error, so I removed this id

Besides this when I was testing if the widget is working again, I noticed that it was not refreshing (when option auto-reload is enabled). It was because after the user changed it to auto-reload, the alarm which should refresh the widget was not set properly.

