### PR TITLE
Logout crash fix

### DIFF
--- a/app/src/main/java/de/tum/in/tumcampusapp/component/other/settings/SettingsFragment.kt
+++ b/app/src/main/java/de/tum/in/tumcampusapp/component/other/settings/SettingsFragment.kt
@@ -48,8 +48,6 @@ import javax.inject.Inject
 class SettingsFragment : PreferenceFragmentCompat(), Preference.OnPreferenceClickListener,
         SharedPreferences.OnSharedPreferenceChangeListener {
 
-    private val themeProvider by lazy { ThemeProvider(requireContext()) }
-
     private val compositeDisposable = CompositeDisposable()
 
     @Inject
@@ -198,7 +196,7 @@ class SettingsFragment : PreferenceFragmentCompat(), Preference.OnPreferenceClic
 
         // Change design theme
         if (key == Const.DESIGN_THEME) {
-            val theme = themeProvider.getTheme(sharedPrefs.getString(key, "system")!!)
+            val theme = ThemeProvider.getTheme(sharedPrefs.getString(key, "system")!!)
             AppCompatDelegate.setDefaultNightMode(theme)
         }
 

--- a/app/src/main/java/de/tum/in/tumcampusapp/component/other/settings/ThemeProvider.kt
+++ b/app/src/main/java/de/tum/in/tumcampusapp/component/other/settings/ThemeProvider.kt
@@ -18,10 +18,12 @@ class ThemeProvider(private val context: Context) {
         } ?: AppCompatDelegate.MODE_NIGHT_FOLLOW_SYSTEM
     }
 
-    fun getTheme(selectedTheme: String): Int = when (selectedTheme) {
-        "system" -> AppCompatDelegate.MODE_NIGHT_FOLLOW_SYSTEM
-        "light" -> UiModeManager.MODE_NIGHT_NO
-        "dark" -> UiModeManager.MODE_NIGHT_YES
-        else -> throw InvalidParameterException("Theme not defined for $selectedTheme")
+    companion object {
+        fun getTheme(selectedTheme: String): Int = when (selectedTheme) {
+            "system" -> AppCompatDelegate.MODE_NIGHT_FOLLOW_SYSTEM
+            "light" -> UiModeManager.MODE_NIGHT_NO
+            "dark" -> UiModeManager.MODE_NIGHT_YES
+            else -> throw InvalidParameterException("Theme not defined for $selectedTheme")
+        }
     }
 }


### PR DESCRIPTION
## Issue

This fixes the following issue(s): #1418 

## Description

There was an issue that ThemeProvider was initialising before context was available, but actually, the function getTheme() that was used, does not need context. So to fix it, I moved getTheme() to a companion object.

