### PR TITLE
Landscape layout fix after rotation

### DIFF
--- a/app/src/main/java/de/tum/in/tumcampusapp/component/tumui/grades/GradesFragment.kt
+++ b/app/src/main/java/de/tum/in/tumcampusapp/component/tumui/grades/GradesFragment.kt
@@ -2,6 +2,7 @@ package de.tum.`in`.tumcampusapp.component.tumui.grades
 
 import android.animation.Animator
 import android.animation.AnimatorListenerAdapter
+import android.content.res.Configuration
 import android.graphics.Color
 import android.os.Bundle
 import android.util.ArrayMap
@@ -11,6 +12,7 @@ import android.view.MenuItem
 import android.view.View
 import android.widget.AdapterView
 import android.widget.ArrayAdapter
+import androidx.core.app.ActivityCompat.recreate
 import androidx.core.content.ContextCompat
 import androidx.core.content.res.ResourcesCompat.getColor
 import com.github.mikephil.charting.components.Legend
@@ -43,6 +45,8 @@ class GradesFragment : FragmentForAccessingTumOnline<ExamList>(
 
     private var showBarChartAfterRotate = false
 
+    private var currentOrientation: Int? = null
+
     private val grades: Array<String> by lazy {
         resources.getStringArray(R.array.grades)
     }
@@ -64,6 +68,8 @@ class GradesFragment : FragmentForAccessingTumOnline<ExamList>(
             showBarChartAfterRotate = !state.getBoolean(KEY_SHOW_BAR_CHART, true)
             spinnerPosition = state.getInt(KEY_SPINNER_POSITION, 0)
         }
+
+        currentOrientation = resources.configuration.orientation
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
@@ -382,6 +388,12 @@ class GradesFragment : FragmentForAccessingTumOnline<ExamList>(
             R.id.pie_chart_menu -> toggleChart().run { true }
             else -> super.onOptionsItemSelected(item)
         }
+    }
+
+    override fun onConfigurationChanged(newConfig: Configuration) {
+        super.onConfigurationChanged(newConfig)
+        if (currentOrientation != newConfig.orientation)
+            recreate(requireActivity())
     }
 
     /**

--- a/app/src/main/res/layout-land/activity_create_event.xml
+++ b/app/src/main/res/layout-land/activity_create_event.xml
@@ -1,0 +1,245 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.drawerlayout.widget.DrawerLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:fitsSystemWindows="true">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:orientation="vertical">
+
+        <!-- The toolbar aka SupportActionBar -->
+        <include layout="@layout/toolbar" />
+
+        <include layout="@layout/layout_all_errors" />
+
+        <androidx.swiperefreshlayout.widget.SwipeRefreshLayout
+            android:id="@+id/swipeRefreshLayout"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent">
+
+            <ScrollView
+                android:layout_width="fill_parent"
+                android:layout_height="fill_parent">
+                <LinearLayout
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:orientation="vertical">
+
+                    <com.google.android.material.textfield.TextInputLayout
+                        style="@style/Widget.MaterialComponents.TextInputLayout.FilledBox"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_margin="@dimen/material_default_padding"
+                        android:hint="@string/event_title">
+
+                        <com.google.android.material.textfield.TextInputEditText
+                            android:id="@+id/eventTitleView"
+                            android:layout_width="match_parent"
+                            android:layout_height="wrap_content"
+                            android:imeOptions="actionDone"
+                            android:inputType="textAutoComplete|textCapSentences"
+                            android:maxLines="1"
+                            android:textCursorDrawable="@drawable/cursor_text_field_colorful"
+                            android:textSize="20sp" />
+
+                    </com.google.android.material.textfield.TextInputLayout>
+
+                    <LinearLayout style="@style/CalendarDateTimeItem">
+
+                        <TextView
+                            android:id="@+id/eventStartDateView"
+                            android:layout_width="0dp"
+                            android:layout_height="match_parent"
+                            android:layout_weight="1"
+                            android:background="?android:selectableItemBackground"
+                            android:clickable="true"
+                            android:focusable="true"
+                            android:gravity="center_vertical"
+                            android:paddingStart="@dimen/material_default_padding"
+                            android:textAppearance="@style/TextAppearance.AppCompat.Medium"
+                            android:textColor="@color/text_primary"
+                            tools:ignore="RtlSymmetry"
+                            tools:text="Mon, Jun 11, 2018" />
+
+                        <TextView
+                            android:id="@+id/eventStartTimeView"
+                            android:layout_width="wrap_content"
+                            android:layout_height="match_parent"
+                            android:background="?android:selectableItemBackground"
+                            android:clickable="true"
+                            android:focusable="true"
+                            android:gravity="center_vertical"
+                            android:paddingStart="@dimen/material_default_padding"
+                            android:paddingEnd="@dimen/material_default_padding"
+                            android:textAppearance="@style/TextAppearance.AppCompat.Medium"
+                            android:textColor="@color/text_primary"
+                            tools:text="11:30" />
+
+                    </LinearLayout>
+
+                    <LinearLayout style="@style/CalendarDateTimeItem">
+
+                        <TextView
+                            android:id="@+id/eventEndDateView"
+                            android:layout_width="0dp"
+                            android:layout_height="match_parent"
+                            android:layout_weight="1"
+                            android:background="?android:selectableItemBackground"
+                            android:clickable="true"
+                            android:focusable="true"
+                            android:gravity="center_vertical"
+                            android:paddingStart="@dimen/material_default_padding"
+                            android:textAppearance="@style/TextAppearance.AppCompat.Medium"
+                            android:textColor="@color/text_primary"
+                            tools:ignore="RtlSymmetry"
+                            tools:text="Mon, Jun 11, 2018" />
+
+                        <TextView
+                            android:id="@+id/eventEndTimeView"
+                            android:layout_width="wrap_content"
+                            android:layout_height="match_parent"
+                            android:background="?android:selectableItemBackground"
+                            android:clickable="true"
+                            android:focusable="true"
+                            android:gravity="center_vertical"
+                            android:paddingStart="@dimen/material_default_padding"
+                            android:paddingEnd="@dimen/material_default_padding"
+                            android:textAppearance="@style/TextAppearance.AppCompat.Medium"
+                            android:textColor="@color/text_primary"
+                            tools:text="12:30" />
+
+                    </LinearLayout>
+
+                    <androidx.appcompat.widget.SwitchCompat
+                        android:id="@+id/repeatingSwitch"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_margin="@dimen/material_default_padding"
+                        android:text="@string/repeats"
+                        android:textAppearance="@style/TextAppearance.AppCompat.Medium" />
+
+                    <LinearLayout
+                        android:id="@+id/repeatingSettings"
+                        android:layout_width="match_parent"
+                        android:layout_height="0dp"
+                        android:orientation="horizontal"
+                        android:layout_marginLeft="@dimen/material_default_padding"
+                        android:layout_marginRight="@dimen/material_default_padding"
+                        android:paddingTop="0dp">
+
+                        <RadioGroup
+                            android:id="@+id/radioGroup2"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content">
+
+                            <RadioButton
+                                android:textAppearance="@style/TextAppearance.AppCompat.Medium"
+                                android:id="@+id/endAfterRadioBtn"
+                                android:layout_width="wrap_content"
+                                android:layout_height="wrap_content"
+                                android:hint="@string/ends_after"
+                                android:textColorHint="@color/text_primary"
+                                android:checked="true"/>
+
+                            <RadioButton
+                                android:textAppearance="@style/TextAppearance.AppCompat.Medium"
+                                android:id="@+id/endOnRadioBtn"
+                                android:layout_width="wrap_content"
+                                android:layout_height="wrap_content"
+                                android:hint="@string/ends_on"
+                                android:textColorHint="@color/text_primary"/>
+
+                        </RadioGroup>
+
+                        <LinearLayout
+                            android:layout_width="match_parent"
+                            android:layout_height="match_parent"
+                            android:orientation="vertical">
+                            <LinearLayout
+                                android:layout_width="match_parent"
+                                android:layout_height="0dp"
+                                android:layout_weight="1"
+                                android:orientation="horizontal">
+                                <EditText
+                                    android:id="@+id/eventRepeatsTimes"
+                                    android:layout_width="wrap_content"
+                                    android:layout_height="wrap_content"
+                                    android:gravity="center_vertical"
+                                    android:hint="14"
+                                    android:inputType="number"
+                                    android:textAppearance="@style/TextAppearance.AppCompat.Medium"
+                                    android:textColor="@color/text_primary"/>
+                                <TextView
+                                    android:layout_width="wrap_content"
+                                    android:layout_height="match_parent"
+                                    android:textAppearance="@style/TextAppearance.AppCompat.Medium"
+                                    android:clickable="true"
+                                    android:focusable="true"
+                                    android:gravity="center_vertical"
+                                    android:text="@string/events"
+                                    android:textColor="@color/text_primary"/>
+                            </LinearLayout>
+                            <TextView
+                                android:id="@+id/eventLastDateView"
+                                android:layout_width="wrap_content"
+                                android:layout_height="0dp"
+                                android:layout_weight="1"
+                                android:clickable="true"
+                                android:focusable="true"
+                                android:gravity="center_vertical"
+                                android:textAppearance="@style/TextAppearance.AppCompat.Medium"
+                                android:textColor="@color/text_primary"
+                                android:text="Mon, Jun 11, 2018"/>
+
+                        </LinearLayout>
+
+                    </LinearLayout>
+
+                    <com.google.android.material.textfield.TextInputLayout
+                        style="@style/Widget.MaterialComponents.TextInputLayout.FilledBox"
+                        android:layout_width="match_parent"
+                        android:layout_height="0dp"
+                        android:layout_margin="@dimen/material_default_padding"
+                        android:layout_weight="1"
+                        android:hint="@string/comment">
+
+                        <com.google.android.material.textfield.TextInputEditText
+                            android:id="@+id/eventDescriptionView"
+                            android:layout_width="match_parent"
+                            android:layout_height="match_parent"
+                            android:background="@android:color/transparent"
+                            android:gravity="top"
+                            android:imeOptions="normal"
+                            android:inputType="textMultiLine|textAutoCorrect|textAutoComplete|textCapSentences"
+                            android:textCursorDrawable="@drawable/cursor_text_field_colorful" />
+
+                    </com.google.android.material.textfield.TextInputLayout>
+
+                    <com.google.android.material.button.MaterialButton
+                        android:id="@+id/createEventButton"
+                        style="@style/Widget.MaterialComponents.Button"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_gravity="end"
+                        android:layout_margin="@dimen/material_default_padding"
+                        android:alpha="0.5"
+                        android:enabled="false"
+                        android:text="@string/save"
+                        android:textAllCaps="false"
+                        android:textColor="@android:color/white"
+                        app:backgroundTint="@color/color_primary"
+                        app:cornerRadius="@dimen/material_corner_radius" />
+
+                </LinearLayout>
+            </ScrollView>
+
+
+        </androidx.swiperefreshlayout.widget.SwipeRefreshLayout>
+
+    </LinearLayout>
+
+</androidx.drawerlayout.widget.DrawerLayout>


### PR DESCRIPTION
## Issue

This fixes the following issue(s): #1377 

## Description

- GradesFragment was not switching to proper layout on rotation, because of android:configChanges="orientation|screenSize" in BaseNavigationActivity, so I made the GradesFragment recreate on orientation changed to fix it
- add a landscape layout for CalendarCreateEvent that supports scrolling
