### PR TITLE
Fix time and date format of lectures with locale(#1453)

### DIFF
--- a/app/src/main/java/de/tum/in/tumcampusapp/component/tumui/lectures/adapter/LectureAppointmentsListAdapter.kt
+++ b/app/src/main/java/de/tum/in/tumcampusapp/component/tumui/lectures/adapter/LectureAppointmentsListAdapter.kt
@@ -12,6 +12,7 @@ import de.tum.`in`.tumcampusapp.component.tumui.lectures.model.LectureAppointmen
 import de.tum.`in`.tumcampusapp.utils.DateTimeUtils
 import de.tum.`in`.tumcampusapp.utils.Utils
 import org.joda.time.format.DateTimeFormat
+import java.util.*
 
 /**
  * Generates the output of the ListView on the [LecturesAppointmentsActivity] activity.
@@ -60,6 +61,11 @@ class LectureAppointmentsListAdapter(
         return view
     }
 
+    // to get current setting language
+    private fun getLocale(): String? {
+        return Locale.getDefault().getLanguage()
+    }
+
     private fun getAppointmentTime(lvItem: LectureAppointment): String {
         val start = lvItem.startTime
         val end = lvItem.endTime
@@ -67,9 +73,17 @@ class LectureAppointmentsListAdapter(
         // output if same day: we only show the date once
         val output = StringBuilder()
         if (DateTimeUtils.isSameDay(start, end)) {
-            output.append(startDateOutput.print(start))
-                    .append("–")
-                    .append(endHoursOutput.print(end))
+            // english time format
+            if (getLocale().equals("en")){
+                output.append(start.toString("EEE MMM dd YYYY, hh:mm a"))
+                        .append("–")
+                        .append(end.toString("hh:mm a"))
+            }
+            else{
+                output.append(start.toString("EEE MMM dd YYYY, kk:mm"))
+                        .append("–")
+                        .append(end.toString("kk:mm"))
+            }
         } else {
             // show it normally
             output.append(startDateOutput.print(start))


### PR DESCRIPTION
## Issue

This fixes the following issue(s): https://github.com/TUM-Dev/Campus-Android/issues/1453

## Screenshot
### Before
<img width="372" alt="스크린샷 2022-06-16 15 50 32" src="https://user-images.githubusercontent.com/75295578/174085180-a788fd24-0fd9-479b-a729-c6864543a8df.png">


### After
1. German time format
<img width="395" alt="스크린샷 2022-06-16 15 15 27" src="https://user-images.githubusercontent.com/75295578/174077998-02730480-9fc7-48df-bc32-0f92545f06e0.png"> 

2. English time format 
<img width="373" alt="스크린샷 2022-06-16 15 55 01" src="https://user-images.githubusercontent.com/75295578/174085870-3894e026-ca20-4419-91b1-afb566d477c4.png">



## Why this is useful for all students
In lecture appointment pages, the seconds of each lecture are displayed even though we don't have to check the seconds of lecture. Through this edit, times of lectures are simplified with just informations needed. In addition, applying some feedbacks, time formats are set with locale(English or German).  
