### PR TITLE
Migration of `kotlin-android-extensions`

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -73,9 +73,6 @@ android {
     sourceSets {
         androidTest.assets.srcDirs += files("$projectDir/schemas".toString())
     }
-    androidExtensions {
-        experimental = true
-    }
     lint {
         abortOnError false
         checkAllWarnings true

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -6,7 +6,7 @@ apply plugin: 'com.android.application'
 apply plugin: 'com.google.gms.google-services'
 apply plugin: 'com.google.protobuf'
 apply plugin: 'kotlin-android'
-apply plugin: 'kotlin-android-extensions'
+apply plugin: 'kotlin-parcelize'
 apply plugin: 'kotlin-kapt'
 apply plugin: "com.github.ben-manes.versions"
 apply plugin: 'com.google.firebase.crashlytics'

--- a/app/src/main/java/de/tum/in/tumcampusapp/component/tumui/feedback/model/Feedback.kt
+++ b/app/src/main/java/de/tum/in/tumcampusapp/component/tumui/feedback/model/Feedback.kt
@@ -5,7 +5,7 @@ import android.os.Build
 import android.os.Parcelable
 import de.tum.`in`.tumcampusapp.BuildConfig
 import de.tum.`in`.tumcampusapp.utils.Const
-import kotlinx.android.parcel.Parcelize
+import kotlinx.parcelize.Parcelize
 import java.util.UUID
 
 /**

--- a/app/src/main/java/de/tum/in/tumcampusapp/component/ui/tufilm/KinoActivity.kt
+++ b/app/src/main/java/de/tum/in/tumcampusapp/component/ui/tufilm/KinoActivity.kt
@@ -6,9 +6,9 @@ import androidx.lifecycle.ViewModelProviders
 import de.tum.`in`.tumcampusapp.R
 import de.tum.`in`.tumcampusapp.component.other.generic.activity.ProgressActivity
 import de.tum.`in`.tumcampusapp.component.ui.tufilm.model.Kino
+import de.tum.`in`.tumcampusapp.databinding.ActivityKinoBinding
 import de.tum.`in`.tumcampusapp.di.ViewModelFactory
 import de.tum.`in`.tumcampusapp.utils.Const
-import kotlinx.android.synthetic.main.activity_kino.*
 import javax.inject.Inject
 import javax.inject.Provider
 
@@ -21,6 +21,7 @@ class KinoActivity : ProgressActivity<Void>(R.layout.activity_kino) {
 
     @Inject
     internal lateinit var viewModelProvider: Provider<KinoViewModel>
+    private lateinit var binding: ActivityKinoBinding;
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -40,8 +41,10 @@ class KinoActivity : ProgressActivity<Void>(R.layout.activity_kino) {
             else -> 0
         }
 
+        binding = ActivityKinoBinding.inflate(layoutInflater)
+
         val margin = resources.getDimensionPixelSize(R.dimen.material_default_padding)
-        kinoViewPager.pageMargin = margin
+        binding.kinoViewPager.pageMargin = margin
 
         kinoViewModel.kinos.observe(this, Observer<List<Kino>> { this.showMoviesOrPlaceholder(it) })
         kinoViewModel.error.observe(this, Observer<Int> { this.showError(it) })
@@ -53,7 +56,7 @@ class KinoActivity : ProgressActivity<Void>(R.layout.activity_kino) {
             return
         }
 
-        kinoViewPager.adapter = KinoAdapter(supportFragmentManager, kinos)
-        kinoViewPager.currentItem = startPosition
+        binding.kinoViewPager.adapter = KinoAdapter(supportFragmentManager, kinos)
+        binding.kinoViewPager.currentItem = startPosition
     }
 }

--- a/gradle/config/detekt-config.yml
+++ b/gradle/config/detekt-config.yml
@@ -362,4 +362,4 @@ style:
     active: false
   WildcardImport:
     active: true
-    excludeImports: 'java.util.*,kotlinx.android.synthetic.*'
+    excludeImports: 'java.util.*'


### PR DESCRIPTION
## Issue
This migrates the `kotlin-android-extensions` Gradle plugin.

Changes:
- `Parcelisise`-ation now comes from the `kotlin-parcelise` package
- we no longer use synthetics

Current Blocker:
we included in #1417 the following block:
```gradle
androidExtensions {
    experimental = true
}
```
@Liqs-v2 what is the reasoning behind this?
Is this still nessesary?
(there is a gradle bug caused by this that I can not, for the live of me, debug..)


This fixes the following issue(s): #1445 

## Why this is useful for all students
The warning is confusing for new developers and should be squashed

resolves #1445 