### PR TITLE
Improved error message for missing specific rights

### DIFF
--- a/app/src/main/java/de/tum/in/tumcampusapp/component/ui/onboarding/CheckTokenFragment.kt
+++ b/app/src/main/java/de/tum/in/tumcampusapp/component/ui/onboarding/CheckTokenFragment.kt
@@ -8,6 +8,7 @@ import com.zhuinden.fragmentviewbindingdelegatekt.viewBinding
 import de.tum.`in`.tumcampusapp.R
 import de.tum.`in`.tumcampusapp.api.tumonline.TUMOnlineClient
 import de.tum.`in`.tumcampusapp.api.tumonline.exception.InactiveTokenException
+import de.tum.`in`.tumcampusapp.api.tumonline.exception.MissingPermissionException
 import de.tum.`in`.tumcampusapp.component.other.generic.fragment.BaseFragment
 import de.tum.`in`.tumcampusapp.component.tumui.person.model.IdentitySet
 import de.tum.`in`.tumcampusapp.component.ui.onboarding.di.OnboardingComponent
@@ -112,6 +113,7 @@ class CheckTokenFragment : BaseFragment<Unit>(
         val messageResId = when (t) {
             is UnknownHostException -> R.string.no_internet_connection
             is InactiveTokenException -> R.string.error_access_token_inactive
+            is MissingPermissionException -> R.string.error_access_token_insufficient_permissions
             else -> R.string.error_unknown
         }
 

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -717,4 +717,5 @@ Signatur: %5$s</string>
     // for opening hours
     <string name="language">de</string>
     <string name="use_existing">Bestehendes verwenden</string>
+    <string name="error_access_token_insufficient_permissions">Deinem TUMonline-Token fehlen die aktiven Rechte!</string>
 </resources>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -654,6 +654,7 @@ Signatur: %5$s</string>
     <string name="error_no_rights_to_access_function">Dein TUMonline-Access-Token hat nicht die nötigte Berechtigung, um diese Funktion zu nutzen.</string>
     <string name="error_request_limit_reached">Du hast das Anfragelimit für TUMonline erreicht. Versuche es später erneut.</string>
     <string name="error_access_token_limit_reached">Limit an Access-Tokens erreicht. Du musst einen Access-Token in TUMonline löschen, bevor du fortfahren kannst.</string>
+    <string name="error_access_token_insufficient_permissions">Deinem TUMonline-Token fehlen die aktiven Rechte!</string>
     <string name="error_unknown">Unbekannter Fehler.</string>
     <string name="export_to_google_error">Ein Fehler ist während des Kalender-Exports zu Google Kalender aufgetreten.</string>
     <string name="checking_if_token_enabled">Überprüfung, ob Token aktiviert ist …</string>
@@ -717,5 +718,4 @@ Signatur: %5$s</string>
     // for opening hours
     <string name="language">de</string>
     <string name="use_existing">Bestehendes verwenden</string>
-    <string name="error_access_token_insufficient_permissions">Deinem TUMonline-Token fehlen die aktiven Rechte!</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -64,6 +64,7 @@
     <string name="error_no_rights_to_access_function">Your TUMonline access token doesn’t have the rights to access this function.</string>
     <string name="error_request_limit_reached">You reached the request limit for TUMonline. Try again later.</string>
     <string name="error_access_token_limit_reached">Token limit reached. You have delete an access token in TUMonline before you can continue.</string>
+    <string name="error_access_token_insufficient_permissions">Your TUMonline access token is missing the specific rights!</string>
     <string name="error_unknown">Unknown error.</string>
     <string name="error_tum_online_unavailable">TUMonline is currently unavailable.</string>
 
@@ -769,5 +770,4 @@ Signature: %5$s</string>
     // for opening hours
     <string name="language">en</string>
     <string name="use_existing">Use existing</string>
-    <string name="error_access_token_insufficient_permissions">Your TUMonline access token is missing the specific rights!</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -769,4 +769,5 @@ Signature: %5$s</string>
     // for opening hours
     <string name="language">en</string>
     <string name="use_existing">Use existing</string>
+    <string name="error_access_token_insufficient_permissions">Your TUMonline access token is missing the specific rights!</string>
 </resources>


### PR DESCRIPTION
## Issue

Fixes #1464 

## Screenshot
<img src="https://user-images.githubusercontent.com/11789478/177783819-ca203043-a6b9-4e36-ac72-7bc159e41121.png" 
width="250px"/>


## Why this is useful for all students
This improves the UX by better explaining what went wrong.

Side note:
During testing, I found another bug, that if you cancel the setup before the token was correctly configured, the app still saves your mail and on restart thinks your setup is complete, although the token setup was never completed. I will add another issues for that.
