### PR TITLE
Fix the current seeing position in calendar

### DIFF
--- a/app/src/main/java/de/tum/in/tumcampusapp/component/tumui/calendar/CalendarFragment.kt
+++ b/app/src/main/java/de/tum/in/tumcampusapp/component/tumui/calendar/CalendarFragment.kt
@@ -438,7 +438,13 @@ class CalendarFragment : FragmentForAccessingTumOnline<EventsResponse>(
         showDate?.let {
             binding.weekView.goToDate(it.toGregorianCalendar())
             binding.weekView.goToHour(it.hourOfDay)
-        } ?: binding.weekView.goToCurrentTime()
+        } ?: run {
+            binding.weekView.firstVisibleDate?.let{
+                binding.weekView.goToDate(it)
+            } ?: run {
+                binding.weekView.goToCurrentTime()
+                }
+            }
 
         menuItemSwitchView?.setIcon(icon)
     }


### PR DESCRIPTION
## Issue & Why this is useful for all students

The position in the calendar always go to the current Date and Time. But it will be more useful to keep the current seeing position in the calendar even when the options are changed to check the schedule of the date that user want to see. 

## Screenshot
This is the changes.

First screen when user go to "Calendar" category, it is same as before.
<img src="https://user-images.githubusercontent.com/75295578/177784344-06343d9b-8fdb-4b19-951a-7b632053734f.png" width="350" height="700"/>

When user scroll the calendar to the date when user want to check, it will be like this(same as before so far)
<img src="https://user-images.githubusercontent.com/75295578/177785173-771ac05a-a87b-4108-9c53-86f8c3d20035.png" width="350" height="700"/>

If user click the button for changing to daily calendar from weekly one, the first seeing date(7/12) is maintained.
<img src="https://user-images.githubusercontent.com/75295578/177785477-6b9ccee9-2637-420a-a9b7-fc42a0581dc6.png" width="350" height="700"/>

In addition, when user want to check canceled events on specific date and change the check box "show canceled events", the current seeing date will also be kept. 
<img src="https://user-images.githubusercontent.com/75295578/177785845-484e0393-9737-4a22-a759-fca486e620e2.png" width="350" height="700"/>
<img src="https://user-images.githubusercontent.com/75295578/177786011-d9805f77-daa6-4cf3-9297-66fbb51d7d53.png" width="350" height="700"/>


Fixes #1469