### PR TITLE
Removed drawer where not necessary

### DIFF
--- a/app/src/main/res/layout/activity_chat.xml
+++ b/app/src/main/res/layout/activity_chat.xml
@@ -74,6 +74,4 @@
 
     </LinearLayout>
 
-    <include layout="@layout/navigation_drawer" />
-
 </androidx.drawerlayout.widget.DrawerLayout>

--- a/app/src/main/res/layout/activity_kino.xml
+++ b/app/src/main/res/layout/activity_kino.xml
@@ -34,6 +34,4 @@
 
     </FrameLayout>
 
-    <include layout="@layout/navigation_drawer" />
-
 </androidx.drawerlayout.widget.DrawerLayout>


### PR DESCRIPTION
## Issue
Empty drawer could be opened from certain views

This fixes the following issue(s):
#1433 

## Screenshot
(No more drawer from the left possible)

## Why this is useful for all students
Bugfix
