### PR TITLE
removed "resolveActivity" check on open camera

### DIFF
--- a/app/src/main/java/de/tum/in/tumcampusapp/component/tumui/feedback/FeedbackPresenter.kt
+++ b/app/src/main/java/de/tum/in/tumcampusapp/component/tumui/feedback/FeedbackPresenter.kt
@@ -1,6 +1,7 @@
 package de.tum.`in`.tumcampusapp.component.tumui.feedback
 
 import android.Manifest.permission.*
+import android.content.ActivityNotFoundException
 import android.content.Context
 import android.content.Intent
 import android.content.pm.PackageManager
@@ -12,6 +13,7 @@ import android.provider.MediaStore
 import android.util.Patterns
 import androidx.annotation.RequiresApi
 import androidx.core.content.ContextCompat
+import androidx.core.content.ContextCompat.startActivity
 import androidx.core.content.FileProvider
 import de.tum.`in`.tumcampusapp.R
 import de.tum.`in`.tumcampusapp.api.app.TUMCabeClient
@@ -107,9 +109,6 @@ class FeedbackPresenter @Inject constructor(
 
     override fun takePicture() {
         val takePictureIntent = Intent(MediaStore.ACTION_IMAGE_CAPTURE)
-        if (takePictureIntent.resolveActivity(context.packageManager) == null) {
-            return
-        }
 
         // Create the file where the photo should go
         var photoFile: File? = null
@@ -127,8 +126,11 @@ class FeedbackPresenter @Inject constructor(
         val authority = "de.tum.in.tumcampusapp.fileprovider"
         val photoURI = FileProvider.getUriForFile(context, authority, photoFile)
         takePictureIntent.putExtra(MediaStore.EXTRA_OUTPUT, photoURI)
-
-        view?.openCamera(takePictureIntent)
+        try {
+            view?.openCamera(takePictureIntent)
+        } catch (e: ActivityNotFoundException) {
+            photoFile.delete()
+        }
     }
 
     override fun openGallery() {

--- a/app/src/main/java/de/tum/in/tumcampusapp/component/tumui/feedback/FeedbackPresenter.kt
+++ b/app/src/main/java/de/tum/in/tumcampusapp/component/tumui/feedback/FeedbackPresenter.kt
@@ -13,7 +13,6 @@ import android.provider.MediaStore
 import android.util.Patterns
 import androidx.annotation.RequiresApi
 import androidx.core.content.ContextCompat
-import androidx.core.content.ContextCompat.startActivity
 import androidx.core.content.FileProvider
 import de.tum.`in`.tumcampusapp.R
 import de.tum.`in`.tumcampusapp.api.app.TUMCabeClient


### PR DESCRIPTION
## Issue
This PR is a fix for a small bug I stumbled on. Since I found a solution rather quickly, I've skipped the creating an additional issue.

The problem was that the camera view in the feedback activity could not be opened.

## Solution
This code (FeedbackPresenter) finished the method too early:

```
if (takePictureIntent.resolveActivity(context.packageManager) == null) {  
    return  
}
```

This check returns null even if successful in more recent API versions. This check is now removed and the potential exception will be caught if the activity does actually not exist. 

## How to test
Open Feedback tab and add a new image with the camera. Camera view should open.

