### PR TITLE
Fix relative date time formatting

### DIFF
--- a/app/src/main/java/de/tum/in/tumcampusapp/utils/DateTimeUtils.kt
+++ b/app/src/main/java/de/tum/in/tumcampusapp/utils/DateTimeUtils.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.text.format.DateUtils.*
 import de.tum.`in`.tumcampusapp.R
 import org.joda.time.DateTime
+import org.joda.time.DateTimeZone
 import org.joda.time.format.DateTimeFormat
 import org.joda.time.format.DateTimeFormatter
 import java.text.ParseException
@@ -45,13 +46,13 @@ object DateTimeUtils {
             diff < 60 * MINUTE_IN_MILLIS -> {
                 val formatter = DateTimeFormat.forPattern("m")
                         .withLocale(Locale.ENGLISH)
-                "${context.getString(R.string.IN)} ${formatter.print(DateTime(diff))}" +
+                "${context.getString(R.string.IN)} ${formatter.print(DateTime(diff, DateTimeZone.UTC))} " +
                         context.getString(R.string.MINUTES)
             }
             diff < 5 * HOUR_IN_MILLIS -> {
                 val formatter = DateTimeFormat.forPattern("h 'h' m 'min'")
                         .withLocale(Locale.ENGLISH)
-                "${context.getString(R.string.IN)} ${formatter.print(DateTime(diff))}"
+                "${context.getString(R.string.IN)} ${formatter.print(DateTime(diff, DateTimeZone.UTC))}"
             }
             else -> getRelativeTimeSpanString(timeInMillis, now, MINUTE_IN_MILLIS,
                     FORMAT_ABBREV_RELATIVE).toString()


### PR DESCRIPTION
This PR fixes relative date formatting being off by one hour in in the Cafeteria screen. Additionally, I added a space before "minuten" when it displays that the mensa closes in e.g. "37 minuten" to be consistent with the spacing in the "x h y min" format.

I have verified that other formatted dates (e.g. in the calendar card on the main screen) continue to show correct relative times.

There does however seem to be a problem: relative time for the mensa card and screen is not displayed when the language is set to English (I assume it's unrelated to this change, but might block this PR).

```
E/ViewRootImpl: Accessibility content change on non-UI thread. Future Android versions will throw an exception.
    android.view.ViewRootImpl$CalledFromWrongThreadException: Only the original thread that created a view hierarchy can touch its views.
        at android.view.ViewRootImpl$SendWindowContentChangedAccessibilityEvent.runOrPost(ViewRootImpl.java:9683)
        at android.view.ViewRootImpl.postSendWindowContentChangedCallback(ViewRootImpl.java:8541)
        at android.view.ViewRootImpl.notifySubtreeAccessibilityStateChanged(ViewRootImpl.java:8721)
        at android.view.ViewGroup.notifySubtreeAccessibilityStateChanged(ViewGroup.java:3833)
        at android.view.ViewGroup.notifySubtreeAccessibilityStateChanged(ViewGroup.java:3833)
        at android.view.ViewGroup.notifySubtreeAccessibilityStateChanged(ViewGroup.java:3833)
        at android.view.ViewGroup.notifySubtreeAccessibilityStateChanged(ViewGroup.java:3833)
        at android.view.ViewGroup.notifySubtreeAccessibilityStateChanged(ViewGroup.java:3833)
        at android.view.ViewGroup.notifySubtreeAccessibilityStateChanged(ViewGroup.java:3833)
        at android.view.ViewGroup.notifySubtreeAccessibilityStateChanged(ViewGroup.java:3833)
        at android.view.ViewGroup.notifySubtreeAccessibilityStateChanged(ViewGroup.java:3833)
        at android.view.ViewGroup.notifySubtreeAccessibilityStateChanged(ViewGroup.java:3833)
        at android.view.ViewGroup.notifySubtreeAccessibilityStateChanged(ViewGroup.java:3833)
        at android.view.ViewGroup.notifySubtreeAccessibilityStateChanged(ViewGroup.java:3833)
        at android.view.ViewGroup.notifySubtreeAccessibilityStateChanged(ViewGroup.java:3833)
        at android.view.View.notifyViewAccessibilityStateChangedIfNeeded(View.java:13730)
        at android.widget.TextView.setText(TextView.java:6334)
        at android.widget.TextView.setText(TextView.java:6156)
        at android.widget.TextView.setText(TextView.java:6108)
        at de.tum.in.tumcampusapp.component.ui.cafeteria.details.CafeteriaDetailsSectionFragment$onViewCreated$1$1.run(CafeteriaDetailsSectionFragment.kt:79)
        at java.util.TimerThread.mainLoop(Timer.java:562)
        at java.util.TimerThread.run(Timer.java:512)
```

## Issue

This fixes the following issue(s):
- Resolves: #1521

## Screenshot

![Screenshot_20221102-125050_Campus](https://user-images.githubusercontent.com/32465636/199488959-9cf4fcbc-a2ca-41ee-bbb9-b93ea88ff785.png) 
![Screenshot_20221102-132530_Campus](https://user-images.githubusercontent.com/32465636/199489480-a865f876-380f-4663-a0d6-2d08650e8c3e.png)



## Why this is useful for all students
Makes knowing when the mensa is open less confusing
