### PR TITLE
Replace calender deprecated methods

### DIFF
--- a/app/src/main/java/de/tum/in/tumcampusapp/component/tumui/calendar/CalendarController.kt
+++ b/app/src/main/java/de/tum/in/tumcampusapp/component/tumui/calendar/CalendarController.kt
@@ -34,7 +34,7 @@ class CalendarController(private val context: Context) : ProvidesCard, ProvidesN
     private val roomLocationsDao: RoomLocationsDao = TcaDb.getInstance(context).roomLocationsDao()
     private val widgetsTimetableBlacklistDao: WidgetsTimetableBlacklistDao = TcaDb.getInstance(context).widgetsTimetableBlacklistDao()
     private val eventColorProvider: EventColorController = EventColorController(context)
-    var requestCode: Int=0
+    var requestCode: Int = 0
 
     /**
      * Get current lecture from the database

--- a/app/src/main/java/de/tum/in/tumcampusapp/component/tumui/calendar/CalendarController.kt
+++ b/app/src/main/java/de/tum/in/tumcampusapp/component/tumui/calendar/CalendarController.kt
@@ -34,6 +34,7 @@ class CalendarController(private val context: Context) : ProvidesCard, ProvidesN
     private val roomLocationsDao: RoomLocationsDao = TcaDb.getInstance(context).roomLocationsDao()
     private val widgetsTimetableBlacklistDao: WidgetsTimetableBlacklistDao = TcaDb.getInstance(context).widgetsTimetableBlacklistDao()
     private val eventColorProvider: EventColorController = EventColorController(context)
+    var requestCode: Int=0
 
     /**
      * Get current lecture from the database

--- a/app/src/main/java/de/tum/in/tumcampusapp/component/tumui/calendar/CalendarFragment.kt
+++ b/app/src/main/java/de/tum/in/tumcampusapp/component/tumui/calendar/CalendarFragment.kt
@@ -47,7 +47,6 @@ class CalendarFragment :
     ),
     CalendarDetailsFragment.OnEventInteractionListener {
 
-
     private val calendarController: CalendarController by lazy {
         CalendarController(requireContext())
     }
@@ -416,8 +415,7 @@ class CalendarFragment :
     }
 
     private val startForResult =
-        registerForActivityResult(ActivityResultContracts.StartActivityForResult())
-        { result: ActivityResult ->
+        registerForActivityResult(ActivityResultContracts.StartActivityForResult()) { result: ActivityResult ->
             if (result.resultCode != Activity.RESULT_OK) {
                 val failed = result.data?.getStringExtra("failed") ?: 1
                 val sum = result.data?.getStringExtra("sum") ?: 1


### PR DESCRIPTION
Removes deprecated Methods `requestPermissions()` and `onActivityResults()` with a non deprecated equivalent

# How to test: 
1. Open calender view.
2. Three dots -> Export to Goolge Calender once with - accept permission - deny permission to test both options.
3. Three dots -> Remove from Google Calender - accept permission - deny permission.
4. Plus in Toolbar -> Add new calender entry -save - must not show an error message.



