### PR TITLE
Next lecture card: show currently ongoing lectures

### DIFF
--- a/app/src/main/java/de/tum/in/tumcampusapp/component/tumui/calendar/CalendarDao.kt
+++ b/app/src/main/java/de/tum/in/tumcampusapp/component/tumui/calendar/CalendarDao.kt
@@ -31,7 +31,7 @@ interface CalendarDao {
 
     @get:Query("SELECT * FROM calendar " +
             "WHERE status!='CANCEL' " +
-            "AND dtstart > datetime('now', 'localtime') " +
+            "AND dtend > datetime('now', 'localtime') " +
             "GROUP BY title, dtstart, dtend " +
             "ORDER BY dtstart LIMIT 4")
     val nextUniqueCalendarItems: List<CalendarItem>

--- a/app/src/main/java/de/tum/in/tumcampusapp/component/tumui/calendar/NextLectureCardViewHolder.kt
+++ b/app/src/main/java/de/tum/in/tumcampusapp/component/tumui/calendar/NextLectureCardViewHolder.kt
@@ -20,6 +20,8 @@ class NextLectureCardViewHolder(itemView: View, interactionListener: CardInterac
     private val lectureContainerLayout = itemView.findViewById<LinearLayout>(R.id.currentLecturesContainer)
 
     fun bind(items: List<NextLectureCard.CardCalendarItem>) = with(itemView) {
+        isExpanded = false
+
         // Split events into "day of next lecture" and "not same day", the latter will be hidden behind the expand button
         val firstLectureDate = items.first().start.toLocalDate()
         val (currentEvents, futureEvents) = items.partition {
@@ -35,24 +37,28 @@ class NextLectureCardViewHolder(itemView: View, interactionListener: CardInterac
         }
 
         addLectures(additionalLecturesLayout, futureEvents)
-        toggleMoreButton(futureEvents.size)
+
+        updateExpansion(futureEvents.size)
 
         moreTextView.setOnClickListener {
             isExpanded = isExpanded.not()
-            additionalLecturesLayout.visibility = if (isExpanded) View.VISIBLE else View.GONE
             toggleMoreButton(futureEvents.size)
         }
 
-        divider.visibility = View.VISIBLE
-        moreTextView.visibility = View.VISIBLE
     }
 
-    private fun toggleMoreButton(remainingItems: Int) = with(itemView) {
+    private fun updateExpansion(remainingItems: Int) = with(itemView) {
         val moreTextFormatString = if (isExpanded) R.string.next_lecture_hide else R.string.next_lecture_show_more
         moreTextView.text = context.getString(moreTextFormatString, remainingItems)
 
         val icon = if (isExpanded) R.drawable.ic_arrow_up_blue else R.drawable.ic_arrow_down_blue
         moreTextView.addCompoundDrawablesWithIntrinsicBounds(start = icon)
+
+        additionalLecturesLayout.visibility = if (isExpanded) View.VISIBLE else View.GONE
+    }
+
+    private fun toggleMoreButton(remainingItems: Int) = with(itemView) {
+        updateExpansion(remainingItems)
 
         // If possible, run the transition on the parent RecyclerView to incorporate sibling views
         TransitionManager.beginDelayedTransition((this.parent ?: this) as ViewGroup)

--- a/app/src/main/java/de/tum/in/tumcampusapp/component/tumui/calendar/NextLectureCardViewHolder.kt
+++ b/app/src/main/java/de/tum/in/tumcampusapp/component/tumui/calendar/NextLectureCardViewHolder.kt
@@ -44,7 +44,6 @@ class NextLectureCardViewHolder(itemView: View, interactionListener: CardInterac
             isExpanded = isExpanded.not()
             toggleMoreButton(futureEvents.size)
         }
-
     }
 
     private fun updateExpansion(remainingItems: Int) = with(itemView) {

--- a/app/src/main/java/de/tum/in/tumcampusapp/component/tumui/calendar/NextLectureCardViewHolder.kt
+++ b/app/src/main/java/de/tum/in/tumcampusapp/component/tumui/calendar/NextLectureCardViewHolder.kt
@@ -13,8 +13,6 @@ import de.tum.`in`.tumcampusapp.utils.addCompoundDrawablesWithIntrinsicBounds
 class NextLectureCardViewHolder(itemView: View, interactionListener: CardInteractionListener) : CardViewHolder(itemView, interactionListener) {
 
     private var isExpanded = false
-    private var didBindAdditional = false
-    private var didBindCurrent = false
 
     private val divider = itemView.findViewById<View>(R.id.divider)
     private val moreTextView = itemView.findViewById<TextView>(R.id.moreTextView)
@@ -28,10 +26,7 @@ class NextLectureCardViewHolder(itemView: View, interactionListener: CardInterac
             it.start.toLocalDate().equals(firstLectureDate)
         }
 
-        if (!didBindCurrent) {
-            addLectures(lectureContainerLayout, currentEvents)
-            didBindCurrent = didBindCurrent.not()
-        }
+        addLectures(lectureContainerLayout, currentEvents)
 
         if (futureEvents.isEmpty()) {
             divider.visibility = View.GONE
@@ -39,19 +34,17 @@ class NextLectureCardViewHolder(itemView: View, interactionListener: CardInterac
             return
         }
 
-        if (!didBindAdditional) {
-            // This is the first call of bind. Therefore, we inflate any additional NextLectureViews
-            // for upcoming events.
-            addLectures(additionalLecturesLayout, futureEvents)
-            toggleMoreButton(futureEvents.size)
-            didBindAdditional = didBindAdditional.not()
-        }
+        addLectures(additionalLecturesLayout, futureEvents)
+        toggleMoreButton(futureEvents.size)
 
         moreTextView.setOnClickListener {
             isExpanded = isExpanded.not()
             additionalLecturesLayout.visibility = if (isExpanded) View.VISIBLE else View.GONE
             toggleMoreButton(futureEvents.size)
         }
+
+        divider.visibility = View.VISIBLE
+        moreTextView.visibility = View.VISIBLE
     }
 
     private fun toggleMoreButton(remainingItems: Int) = with(itemView) {
@@ -66,6 +59,8 @@ class NextLectureCardViewHolder(itemView: View, interactionListener: CardInterac
     }
 
     private fun addLectures(layout: LinearLayout, lectures: List<NextLectureCard.CardCalendarItem>) = with(itemView) {
+        layout.removeAllViews()
+
         lectures.forEach { item ->
             val lectureView = NextLectureView(context).apply {
                 setLecture(item)

--- a/app/src/main/java/de/tum/in/tumcampusapp/component/tumui/calendar/NextLectureView.kt
+++ b/app/src/main/java/de/tum/in/tumcampusapp/component/tumui/calendar/NextLectureView.kt
@@ -1,6 +1,7 @@
 package de.tum.`in`.tumcampusapp.component.tumui.calendar
 
 import android.content.Context
+import android.text.format.DateUtils.*
 import android.util.AttributeSet
 import android.view.LayoutInflater
 import android.view.View
@@ -8,13 +9,12 @@ import android.widget.LinearLayout
 import android.widget.TextView
 import androidx.appcompat.app.AppCompatActivity
 import de.tum.`in`.tumcampusapp.R
-import de.tum.`in`.tumcampusapp.utils.DateTimeUtils
+import org.joda.time.DateTime
+import org.joda.time.format.DateTimeFormat
+import java.util.*
 
-class NextLectureView @JvmOverloads constructor(
-    context: Context,
-    attrs: AttributeSet? = null,
-    defStyleAttr: Int = 0
-) : LinearLayout(context, attrs, defStyleAttr) {
+class NextLectureView
+@JvmOverloads constructor(context: Context, attrs: AttributeSet? = null, defStyleAttr: Int = 0) : LinearLayout(context, attrs, defStyleAttr) {
 
     private val view = LayoutInflater.from(context).inflate(R.layout.layout_card_lecture, this, true)
 
@@ -24,7 +24,7 @@ class NextLectureView @JvmOverloads constructor(
         val lectureTitleTextView = view.findViewById<TextView>(R.id.lectureTitleTextView)
 
         lectureTitleTextView.text = lecture.title
-        lectureTimeTextView.text = DateTimeUtils.formatFutureTime(lecture.start, context)
+        lectureTimeTextView.text = formatLectureDate(lecture.start, context)
 
         if (lecture.locations == null || lecture.locations.isEmpty()) {
             lectureLocationTextView.visibility = View.GONE
@@ -33,14 +33,54 @@ class NextLectureView @JvmOverloads constructor(
             lectureLocationTextView.text = lecture.locationString
         }
 
-        view.setOnClickListener {
-            openEventBottomSheet(lecture)
+        view.setOnClickListener { openEventBottomSheet(lecture) }
+    }
+
+    /**
+     * Format a recently started or future date.
+     * Examples:
+     * - "Ongoing since 14:15"
+     * - "Starts now"
+     * - "In 32 minutes"
+     * - "Today 18:30"
+     * - "Tomorrow 08:30"
+     * - "In 4 days"
+     */
+    private fun formatLectureDate(startTime: DateTime, context: Context): String {
+        val timeInMillis = startTime.millis
+        val now = DateTime.now()
+
+        val diff = timeInMillis - now.millis
+
+        return when {
+            diff < 0 -> {
+                val diffInMinutes = (-diff / MINUTE_IN_MILLIS)
+                context.getString(R.string.ongoing_since_minutes, diffInMinutes)
+            }
+            diff < MINUTE_IN_MILLIS -> {
+                context.getString(R.string.starts_now)
+            }
+            diff < HOUR_IN_MILLIS -> {
+                val diffInMinutes = diff / MINUTE_IN_MILLIS
+                context.getString(R.string.in_minutes, diffInMinutes)
+            }
+            // Today
+            startTime.dayOfYear() == now.dayOfYear() && startTime.year() == now.year() -> {
+                DateTimeFormat.forPattern("HH:mm").withLocale(Locale.ENGLISH).print(startTime)
+            }
+            // Tomorrow
+            now.withDurationAdded(DAY_IN_MILLIS, 1).let { tomorrow ->
+                startTime.dayOfYear() == tomorrow.dayOfYear() && startTime.year() == tomorrow.year()
+            } -> {
+                val timeStr = DateTimeFormat.forPattern("HH:mm").withLocale(Locale.ENGLISH).print(startTime)
+                context.getString(R.string.tomorrow_time, timeStr)
+            }
+            else -> getRelativeTimeSpanString(timeInMillis, now.millis, MINUTE_IN_MILLIS, FORMAT_ABBREV_RELATIVE).toString()
         }
     }
 
     private fun openEventBottomSheet(item: NextLectureCard.CardCalendarItem) {
-        val detailsFragment =
-                CalendarDetailsFragment.newInstance(item.id, isShownInCalendarActivity = false)
+        val detailsFragment = CalendarDetailsFragment.newInstance(item.id, isShownInCalendarActivity = false)
         val activity = context as AppCompatActivity
         detailsFragment.show(activity.supportFragmentManager, null)
     }

--- a/app/src/main/res/layout/card_next_lecture_item.xml
+++ b/app/src/main/res/layout/card_next_lecture_item.xml
@@ -7,44 +7,27 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content">
 
-        <ImageButton
-            android:id="@+id/cardMoreIcon"
-            style="@style/CardMoreIcon"
-            android:layout_marginTop="@dimen/material_small_padding"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintTop_toTopOf="parent" />
-
         <LinearLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:orientation="vertical"
-            android:paddingTop="@dimen/material_small_padding">
+            android:paddingTop="@dimen/material_small_padding"
+            android:visibility="visible"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            tools:visibility="visible">
 
-            <de.tum.in.tumcampusapp.component.tumui.calendar.NextLectureView
-                android:id="@+id/lectureContainer1"
+            <LinearLayout
+                android:id="@+id/currentLecturesContainer"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:layout_marginBottom="@dimen/material_small_padding" />
+                android:orientation="vertical"
+                android:paddingBottom="@dimen/material_small_padding">
 
-            <View
-                android:id="@+id/divider"
-                android:layout_width="match_parent"
-                android:layout_height="1dp"
-                android:background="@color/spinner_border" />
+                <!-- Add more NextLectureViews here -->
 
-            <TextView
-                android:id="@+id/moreTextView"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:drawableStart="@drawable/ic_arrow_down_blue"
-                android:drawablePadding="@dimen/material_small_padding"
-                android:gravity="center_vertical"
-                android:paddingStart="@dimen/material_default_padding"
-                android:paddingTop="@dimen/material_small_padding"
-                android:paddingEnd="@dimen/material_default_padding"
-                android:paddingBottom="@dimen/material_small_padding"
-                android:textColor="@color/tum_blue"
-                tools:text="Show 3 more ..." />
+            </LinearLayout>
 
             <LinearLayout
                 android:id="@+id/additionalLecturesLayout"
@@ -58,7 +41,35 @@
 
             </LinearLayout>
 
+            <View
+                android:id="@+id/divider"
+                android:layout_width="match_parent"
+                android:layout_height="1dp"
+                android:background="@color/spinner_border" />
+
+            <TextView
+                android:id="@+id/moreTextView"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:drawablePadding="@dimen/material_small_padding"
+                android:drawableStart="@drawable/ic_arrow_down_blue"
+                android:gravity="center_vertical"
+                android:paddingBottom="@dimen/material_small_padding"
+                android:paddingEnd="@dimen/material_default_padding"
+                android:paddingStart="@dimen/material_default_padding"
+                android:paddingTop="@dimen/material_small_padding"
+                android:textColor="@color/tum_blue"
+                tools:text="Show 3 more ..." />
+
         </LinearLayout>
+
+        <ImageButton
+            android:id="@+id/cardMoreIcon"
+            style="@style/CardMoreIcon"
+            android:layout_height="48dp"
+            android:layout_marginTop="@dimen/material_small_padding"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
 
     </androidx.constraintlayout.widget.ConstraintLayout>
 

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -794,8 +794,8 @@ Signatur: %5$s</string>
     <string name="redirect">Umleiten</string>
 
     // Lecture View
-    <string name="ongoing_since_minutes">Läuft seit %1$s Minuten</string>
+    <string name="ongoing_until">Noch %1$s</string>
     <string name="starts_now">Startet jetzt</string>
-    <string name="in_minutes">In %1$s Minuten</string>
     <string name="tomorrow_time">Morgen %1$s</string>
+    <string name="IN_capitalized">In</string>
 </resources>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -793,4 +793,9 @@ Signatur: %5$s</string>
     <string name="not_implemented_interactive_map">Interaktive Karte ist noch nicht implementiert. Sie können auf der NavigaTum-Website darauf zugreifen.</string>
     <string name="redirect">Umleiten</string>
 
+    // Lecture View
+    <string name="ongoing_since_minutes">Läuft seit %1$s Minuten</string>
+    <string name="starts_now">Startet jetzt</string>
+    <string name="in_minutes">In %1$s Minuten</string>
+    <string name="tomorrow_time">Morgen %1$s</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -847,4 +847,10 @@ Signature: %5$s</string>
     <string name="not_implemented">Feature not implemented yet</string>
     <string name="not_implemented_interactive_map">Interactive map is not yet implemented. You can access it on NavigaTum website.</string>
     <string name="redirect">Redirect</string>
+
+    // Lecture View
+    <string name="ongoing_since_minutes">Ongoing since %1$s minutes</string>
+    <string name="starts_now">Starts now</string>
+    <string name="in_minutes">In %1$s minutes</string>
+    <string name="tomorrow_time">Tomorrow %1$s</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -849,8 +849,8 @@ Signature: %5$s</string>
     <string name="redirect">Redirect</string>
 
     // Lecture View
-    <string name="ongoing_since_minutes">Ongoing since %1$s minutes</string>
+    <string name="ongoing_until">" %1$s left"</string>
     <string name="starts_now">Starts now</string>
-    <string name="in_minutes">In %1$s minutes</string>
     <string name="tomorrow_time">Tomorrow %1$s</string>
+    <string name="IN_capitalized">In</string>
 </resources>


### PR DESCRIPTION
This PR changes the "Next lecture" card of the overview screen to show up to 4 lectures of the current day (the day of the next calendar event) that have not yet ended instead of just one.

## Issue

This fixes the following issue(s):
- Resolves: #1540

## Screenshot
| Normal | Expanded |
| ---- | ---- |
| ![normal](https://user-images.githubusercontent.com/32465636/208613999-3b6f999c-0a69-4550-b30b-28a587749442.png) | ![expanded](https://user-images.githubusercontent.com/32465636/208614009-7722864f-a754-4216-8a55-011fc7b2206a.png) |

## Why this is useful for all students
This allows you to get a quick overview of the rest of the day, while still showing currently ongoing lectures (and thus still showing you where to go if you are late) as well as overlapping lectures

----

This PR is currently a draft to discuss the following:
* In settings this is called "Nächste Vorlesung", but now it shows multiple. Should I rename that as well (including the class names)?
* Should we change the time formatting code to work for past lectures, e.g. in case of the screenshot it could make sense to display 08:30-10:00 instead of just the start time?
    * I think it would also make sense to display e.g. "Morgen 11:00" instead of just "Morgen" in the expanded item of the screenshot 