### PR TITLE
fix mensa widget by adding FLAG_IMMUTABLE to Intent

### DIFF
--- a/app/src/main/java/de/tum/in/tumcampusapp/component/ui/cafeteria/widget/MensaWidget.kt
+++ b/app/src/main/java/de/tum/in/tumcampusapp/component/ui/cafeteria/widget/MensaWidget.kt
@@ -1,6 +1,7 @@
 package de.tum.`in`.tumcampusapp.component.ui.cafeteria.widget
 
 import android.app.PendingIntent
+import android.app.PendingIntent.FLAG_IMMUTABLE
 import android.appwidget.AppWidgetManager
 import android.appwidget.AppWidgetProvider
 import android.content.Context
@@ -44,7 +45,7 @@ class MensaWidget : AppWidgetProvider() {
             val mensaIntent = Intent(context, CafeteriaActivity::class.java).apply {
                 putExtra(Const.CAFETERIA_ID, mensaManager.bestMatchMensaId)
             }
-            val pendingIntent = PendingIntent.getActivity(context, appWidgetId, mensaIntent, 0)
+            val pendingIntent = PendingIntent.getActivity(context, appWidgetId, mensaIntent, FLAG_IMMUTABLE)
             remoteViews.setOnClickPendingIntent(R.id.mensa_widget_header_container, pendingIntent)
 
             // Set the adapter for the list view in the mensa widget


### PR DESCRIPTION
## Issue

This fixes the following issue(s):
The mensa widget was blank since it's Intent was forgotten in #1429.

## Solution
Fixed by adding `FLAG_IMMUTABLE` to Intent.

