### PR TITLE
Replaced Outdated Get Color Function

### DIFF
--- a/app/src/main/java/de/tum/in/tumcampusapp/component/tumui/calendar/CalendarHelper.kt
+++ b/app/src/main/java/de/tum/in/tumcampusapp/component/tumui/calendar/CalendarHelper.kt
@@ -41,7 +41,7 @@ object CalendarHelper {
     }
 
     private fun buildCalendarUri(): Uri {
-        return CalendarContract.Calendars.CONTENT_URI.buildUpon()
+        return Calendars.CONTENT_URI.buildUpon()
                 .appendQueryParameter(CalendarContract.CALLER_IS_SYNCADAPTER, "true")
                 .appendQueryParameter(Calendars.ACCOUNT_NAME, ACCOUNT_NAME)
                 .appendQueryParameter(Calendars.ACCOUNT_TYPE, CalendarContract.ACCOUNT_TYPE_LOCAL)
@@ -49,7 +49,10 @@ object CalendarHelper {
     }
 
     private fun buildContentValues(c: Context): ContentValues {
-        val calendarColor = c.resources.getColor(R.color.calendar_color)
+        val calendarColor = ContextCompat.getColor(
+            c.applicationContext,
+            R.color.calendar_color
+        )
         val intName = ACCOUNT_NAME + CALENDAR_NAME
         return ContentValues().apply {
             put(Calendars.ACCOUNT_NAME, ACCOUNT_NAME)

--- a/app/src/main/java/de/tum/in/tumcampusapp/component/tumui/grades/ExamListAdapter.kt
+++ b/app/src/main/java/de/tum/in/tumcampusapp/component/tumui/grades/ExamListAdapter.kt
@@ -108,10 +108,16 @@ class ExamListAdapter(context: Context, results: List<Exam>, gradesFragment: Gra
                     }
                 dialog.show()
                 dialog.getButton(AlertDialog.BUTTON_NEGATIVE).setTextColor(
-                    localGradesFragment.resources.getColor(R.color.text_primary)
+                    ContextCompat.getColor(
+                        context.applicationContext,
+                        R.color.text_primary
+                    )
                 )
                 dialog.getButton(AlertDialog.BUTTON_POSITIVE).setTextColor(
-                    localGradesFragment.resources.getColor(R.color.text_primary)
+                    ContextCompat.getColor(
+                        context.applicationContext,
+                        R.color.text_primary
+                    )
                 )
             }
         } else {

--- a/app/src/main/java/de/tum/in/tumcampusapp/component/tumui/grades/GradesFragment.kt
+++ b/app/src/main/java/de/tum/in/tumcampusapp/component/tumui/grades/GradesFragment.kt
@@ -299,7 +299,10 @@ class GradesFragment : FragmentForAccessingTumOnline<ExamList>(
 
         val set = BarDataSet(entries, "").apply {
             setColors(GRADE_COLORS, requireContext())
-            valueTextColor = resources.getColor(R.color.text_primary)
+            ContextCompat.getColor(
+                requireContext().applicationContext,
+                R.color.text_primary
+            )
         }
         set.setDrawValues(false)
 

--- a/app/src/main/java/de/tum/in/tumcampusapp/component/ui/transportation/MVVSymbol.kt
+++ b/app/src/main/java/de/tum/in/tumcampusapp/component/ui/transportation/MVVSymbol.kt
@@ -1,6 +1,7 @@
 package de.tum.`in`.tumcampusapp.component.ui.transportation
 
 import android.content.Context
+import androidx.core.content.ContextCompat
 import de.tum.`in`.tumcampusapp.R
 
 /**
@@ -54,12 +55,21 @@ class MVVSymbol(line: String, val context: Context) {
             }
         }
 
-        this.textColor = context.resources.getColor(textColor)
-        this.backgroundColor = context.resources.getColor(backgroundColor)
+        this.textColor = ContextCompat.getColor(
+            context.applicationContext,
+            textColor
+        )
+        this.backgroundColor = ContextCompat.getColor(
+            context.applicationContext,
+            backgroundColor
+        )
     }
 
     fun getHighlight(): Int {
-        return context.resources.getColor(R.color.reduced_opacity) and backgroundColor
+        return ContextCompat.getColor(
+            context.applicationContext,
+            R.color.reduced_opacity
+        ) and backgroundColor
     }
 
     companion object {


### PR DESCRIPTION
### Changes
Replaced getColor() with the non deprecated version.

### How to test
check whether colors are displayed correctly in calender, grades and MVV Fragments.
