### PR TITLE
Made Ok and Cancel Buttons in Date- and TimePicker more visible

### DIFF
--- a/app/src/main/java/de/tum/in/tumcampusapp/component/tumui/calendar/CreateEventActivity.kt
+++ b/app/src/main/java/de/tum/in/tumcampusapp/component/tumui/calendar/CreateEventActivity.kt
@@ -4,6 +4,7 @@ import android.app.Activity
 import android.app.DatePickerDialog
 import android.app.TimePickerDialog
 import android.content.Context
+import android.content.DialogInterface
 import android.content.Intent
 import android.content.res.ColorStateList
 import android.os.Bundle
@@ -303,41 +304,67 @@ class CreateEventActivity : ActivityForAccessingTumOnline<CreateEventResponse>(R
         // starts counting months at 1.
         binding.eventStartDateView.setOnClickListener {
             hideKeyboard()
-            DatePickerDialog(this, { _, year, month, dayOfMonth ->
+            val datePickerDialogStart = DatePickerDialog(this, { _, year, month, dayOfMonth ->
                 start = start.withDate(year, month + 1, dayOfMonth)
                 if (end.isBefore(start)) {
                     end = end.withDate(year, month + 1, dayOfMonth)
                 }
                 updateDateViews()
-            }, start.year, start.monthOfYear - 1, start.dayOfMonth).show()
+            }, start.year, start.monthOfYear - 1, start.dayOfMonth)
+
+            datePickerDialogStart.setOnShowListener {
+                datePickerDialogStart.getButton(DialogInterface.BUTTON_POSITIVE).setTextColor(getColor(R.color.text_primary))
+                datePickerDialogStart.getButton(DialogInterface.BUTTON_NEGATIVE).setTextColor(getColor(R.color.text_primary))
+            }
+            datePickerDialogStart.show()
         }
         binding.eventEndDateView.setOnClickListener {
             hideKeyboard()
-            DatePickerDialog(this, { _, year, month, dayOfMonth ->
+            val datePickerDialogEnd = DatePickerDialog(this, { _, year, month, dayOfMonth ->
                 end = end.withDate(year, month + 1, dayOfMonth)
                 updateDateViews()
-            }, start.year, start.monthOfYear - 1, start.dayOfMonth).show()
+            }, start.year, start.monthOfYear - 1, start.dayOfMonth)
+
+            datePickerDialogEnd.setOnShowListener {
+                datePickerDialogEnd.getButton(DialogInterface.BUTTON_POSITIVE).setTextColor(getColor(R.color.text_primary))
+                datePickerDialogEnd.getButton(DialogInterface.BUTTON_NEGATIVE).setTextColor(getColor(R.color.text_primary))
+            }
+            datePickerDialogEnd.show()
         }
 
         // TIME
         binding.eventStartTimeView.setOnClickListener { view ->
             hideKeyboard()
-            TimePickerDialog(this, { timePicker, hour, minute ->
+            val timePickerDialogStart = TimePickerDialog(this, { timePicker, hour, minute ->
+                timePicker.layoutParams = LinearLayout.LayoutParams(
+                        LinearLayout.LayoutParams.WRAP_CONTENT, LinearLayout.LayoutParams.WRAP_CONTENT)
                 val eventLength = end.millis - start.millis
                 start = start.withHourOfDay(hour)
                     .withMinuteOfHour(minute)
                 end = end.withMillis(start.millis + eventLength)
                 updateTimeViews()
-            }, start.hourOfDay, start.minuteOfHour, true).show()
+            }, start.hourOfDay, start.minuteOfHour, true)
+
+            timePickerDialogStart.setOnShowListener {
+                timePickerDialogStart.getButton(DialogInterface.BUTTON_POSITIVE).setTextColor(getColor(R.color.text_primary))
+                timePickerDialogStart.getButton(DialogInterface.BUTTON_NEGATIVE).setTextColor(getColor(R.color.text_primary))
+            }
+            timePickerDialogStart.show()
         }
 
         binding.eventEndTimeView.setOnClickListener { view ->
             hideKeyboard()
-            TimePickerDialog(this, { timePicker, hour, minute ->
+            val timePickerDialogEnd = TimePickerDialog(this, { timePicker, hour, minute ->
                 end = end.withHourOfDay(hour)
                     .withMinuteOfHour(minute)
                 updateTimeViews()
-            }, end.hourOfDay, end.minuteOfHour, true).show()
+            }, end.hourOfDay, end.minuteOfHour, true)
+
+            timePickerDialogEnd.setOnShowListener {
+                timePickerDialogEnd.getButton(DialogInterface.BUTTON_POSITIVE).setTextColor(getColor(R.color.text_primary))
+                timePickerDialogEnd.getButton(DialogInterface.BUTTON_NEGATIVE).setTextColor(getColor(R.color.text_primary))
+            }
+            timePickerDialogEnd.show()
         }
     }
 

--- a/app/src/main/java/de/tum/in/tumcampusapp/component/tumui/calendar/CreateEventActivity.kt
+++ b/app/src/main/java/de/tum/in/tumcampusapp/component/tumui/calendar/CreateEventActivity.kt
@@ -1,6 +1,7 @@
 package de.tum.`in`.tumcampusapp.component.tumui.calendar
 
 import android.app.Activity
+import android.app.AlertDialog
 import android.app.DatePickerDialog
 import android.app.TimePickerDialog
 import android.content.Context
@@ -312,10 +313,7 @@ class CreateEventActivity : ActivityForAccessingTumOnline<CreateEventResponse>(R
                 updateDateViews()
             }, start.year, start.monthOfYear - 1, start.dayOfMonth)
 
-            datePickerDialogStart.setOnShowListener {
-                datePickerDialogStart.getButton(DialogInterface.BUTTON_POSITIVE).setTextColor(getColor(R.color.text_primary))
-                datePickerDialogStart.getButton(DialogInterface.BUTTON_NEGATIVE).setTextColor(getColor(R.color.text_primary))
-            }
+            setDialogButtonColors(datePickerDialogStart)
             datePickerDialogStart.show()
         }
         binding.eventEndDateView.setOnClickListener {
@@ -325,10 +323,7 @@ class CreateEventActivity : ActivityForAccessingTumOnline<CreateEventResponse>(R
                 updateDateViews()
             }, start.year, start.monthOfYear - 1, start.dayOfMonth)
 
-            datePickerDialogEnd.setOnShowListener {
-                datePickerDialogEnd.getButton(DialogInterface.BUTTON_POSITIVE).setTextColor(getColor(R.color.text_primary))
-                datePickerDialogEnd.getButton(DialogInterface.BUTTON_NEGATIVE).setTextColor(getColor(R.color.text_primary))
-            }
+            setDialogButtonColors(datePickerDialogEnd)
             datePickerDialogEnd.show()
         }
 
@@ -345,10 +340,7 @@ class CreateEventActivity : ActivityForAccessingTumOnline<CreateEventResponse>(R
                 updateTimeViews()
             }, start.hourOfDay, start.minuteOfHour, true)
 
-            timePickerDialogStart.setOnShowListener {
-                timePickerDialogStart.getButton(DialogInterface.BUTTON_POSITIVE).setTextColor(getColor(R.color.text_primary))
-                timePickerDialogStart.getButton(DialogInterface.BUTTON_NEGATIVE).setTextColor(getColor(R.color.text_primary))
-            }
+            setDialogButtonColors(timePickerDialogStart)
             timePickerDialogStart.show()
         }
 
@@ -360,11 +352,17 @@ class CreateEventActivity : ActivityForAccessingTumOnline<CreateEventResponse>(R
                 updateTimeViews()
             }, end.hourOfDay, end.minuteOfHour, true)
 
-            timePickerDialogEnd.setOnShowListener {
-                timePickerDialogEnd.getButton(DialogInterface.BUTTON_POSITIVE).setTextColor(getColor(R.color.text_primary))
-                timePickerDialogEnd.getButton(DialogInterface.BUTTON_NEGATIVE).setTextColor(getColor(R.color.text_primary))
-            }
+            setDialogButtonColors(timePickerDialogEnd)
             timePickerDialogEnd.show()
+        }
+    }
+
+    private fun setDialogButtonColors(dialog: AlertDialog) {
+        dialog.setOnShowListener {
+            val positiveButton = dialog.getButton(DialogInterface.BUTTON_POSITIVE)
+            val negativeButton = dialog.getButton(DialogInterface.BUTTON_NEGATIVE)
+            positiveButton.setTextColor(getColor(R.color.text_primary))
+            negativeButton.setTextColor(getColor(R.color.text_primary))
         }
     }
 

--- a/app/src/main/java/de/tum/in/tumcampusapp/component/tumui/calendar/CreateEventActivity.kt
+++ b/app/src/main/java/de/tum/in/tumcampusapp/component/tumui/calendar/CreateEventActivity.kt
@@ -1,11 +1,8 @@
 package de.tum.`in`.tumcampusapp.component.tumui.calendar
 
 import android.app.Activity
-import android.app.AlertDialog
 import android.app.DatePickerDialog
-import android.app.TimePickerDialog
 import android.content.Context
-import android.content.DialogInterface
 import android.content.Intent
 import android.content.res.ColorStateList
 import android.os.Bundle
@@ -17,7 +14,6 @@ import android.view.ViewGroup
 import android.view.inputmethod.InputMethodManager
 import android.widget.LinearLayout
 import android.widget.Toast
-import de.tum.`in`.tumcampusapp.utils.ThemedAlertDialogBuilder
 import androidx.core.content.ContextCompat
 import de.tum.`in`.tumcampusapp.R
 import de.tum.`in`.tumcampusapp.api.tumonline.exception.RequestLimitReachedException
@@ -29,8 +25,7 @@ import de.tum.`in`.tumcampusapp.component.tumui.calendar.model.EventSeriesMappin
 import de.tum.`in`.tumcampusapp.component.tumui.calendar.model.RepeatHelper
 import de.tum.`in`.tumcampusapp.database.TcaDb
 import de.tum.`in`.tumcampusapp.databinding.ActivityCreateEventBinding
-import de.tum.`in`.tumcampusapp.utils.Const
-import de.tum.`in`.tumcampusapp.utils.Utils
+import de.tum.`in`.tumcampusapp.utils.*
 import org.jetbrains.anko.sdk27.coroutines.textChangedListener
 import org.joda.time.DateTime
 import org.joda.time.LocalDate
@@ -305,32 +300,26 @@ class CreateEventActivity : ActivityForAccessingTumOnline<CreateEventResponse>(R
         // starts counting months at 1.
         binding.eventStartDateView.setOnClickListener {
             hideKeyboard()
-            val datePickerDialogStart = DatePickerDialog(this, { _, year, month, dayOfMonth ->
+            ThemedDatePickerDialog(this, { _, year, month, dayOfMonth ->
                 start = start.withDate(year, month + 1, dayOfMonth)
                 if (end.isBefore(start)) {
                     end = end.withDate(year, month + 1, dayOfMonth)
                 }
                 updateDateViews()
-            }, start.year, start.monthOfYear - 1, start.dayOfMonth)
-
-            setDialogButtonColors(datePickerDialogStart)
-            datePickerDialogStart.show()
+            }, start.year, start.monthOfYear - 1, start.dayOfMonth).show()
         }
         binding.eventEndDateView.setOnClickListener {
             hideKeyboard()
-            val datePickerDialogEnd = DatePickerDialog(this, { _, year, month, dayOfMonth ->
+            ThemedDatePickerDialog(this, { _, year, month, dayOfMonth ->
                 end = end.withDate(year, month + 1, dayOfMonth)
                 updateDateViews()
-            }, start.year, start.monthOfYear - 1, start.dayOfMonth)
-
-            setDialogButtonColors(datePickerDialogEnd)
-            datePickerDialogEnd.show()
+            }, start.year, start.monthOfYear - 1, start.dayOfMonth).show()
         }
 
         // TIME
-        binding.eventStartTimeView.setOnClickListener { view ->
+        binding.eventStartTimeView.setOnClickListener {
             hideKeyboard()
-            val timePickerDialogStart = TimePickerDialog(this, { timePicker, hour, minute ->
+            ThemedTimePickerDialog(this, { timePicker, hour, minute ->
                 timePicker.layoutParams = LinearLayout.LayoutParams(
                         LinearLayout.LayoutParams.WRAP_CONTENT, LinearLayout.LayoutParams.WRAP_CONTENT)
                 val eventLength = end.millis - start.millis
@@ -338,31 +327,16 @@ class CreateEventActivity : ActivityForAccessingTumOnline<CreateEventResponse>(R
                     .withMinuteOfHour(minute)
                 end = end.withMillis(start.millis + eventLength)
                 updateTimeViews()
-            }, start.hourOfDay, start.minuteOfHour, true)
-
-            setDialogButtonColors(timePickerDialogStart)
-            timePickerDialogStart.show()
+            }, start.hourOfDay, start.minuteOfHour).show()
         }
 
-        binding.eventEndTimeView.setOnClickListener { view ->
+        binding.eventEndTimeView.setOnClickListener {
             hideKeyboard()
-            val timePickerDialogEnd = TimePickerDialog(this, { timePicker, hour, minute ->
+            ThemedTimePickerDialog(this, { _, hour, minute ->
                 end = end.withHourOfDay(hour)
                     .withMinuteOfHour(minute)
                 updateTimeViews()
-            }, end.hourOfDay, end.minuteOfHour, true)
-
-            setDialogButtonColors(timePickerDialogEnd)
-            timePickerDialogEnd.show()
-        }
-    }
-
-    private fun setDialogButtonColors(dialog: AlertDialog) {
-        dialog.setOnShowListener {
-            val positiveButton = dialog.getButton(DialogInterface.BUTTON_POSITIVE)
-            val negativeButton = dialog.getButton(DialogInterface.BUTTON_NEGATIVE)
-            positiveButton.setTextColor(getColor(R.color.text_primary))
-            negativeButton.setTextColor(getColor(R.color.text_primary))
+            }, end.hourOfDay, end.minuteOfHour).show()
         }
     }
 

--- a/app/src/main/java/de/tum/in/tumcampusapp/utils/ThemedDatePickerDialog.kt
+++ b/app/src/main/java/de/tum/in/tumcampusapp/utils/ThemedDatePickerDialog.kt
@@ -1,0 +1,19 @@
+package de.tum.`in`.tumcampusapp.utils
+
+import android.app.AlertDialog
+import android.app.DatePickerDialog
+import android.content.Context
+import androidx.core.content.ContextCompat
+import de.tum.`in`.tumcampusapp.R
+
+class ThemedDatePickerDialog(context: Context, listener: OnDateSetListener, year: Int, month: Int, dayOfMonth: Int) :
+    DatePickerDialog(context, listener, year, month, dayOfMonth) {
+    override fun show() {
+        window?.setBackgroundDrawableResource(R.drawable.rounded_corners_background)
+        setOnShowListener {
+            getButton(AlertDialog.BUTTON_POSITIVE)?.setTextColor(ContextCompat.getColor(context, R.color.text_primary))
+            getButton(AlertDialog.BUTTON_NEGATIVE)?.setTextColor(ContextCompat.getColor(context, R.color.text_primary))
+        }
+        return super.show()
+    }
+}

--- a/app/src/main/java/de/tum/in/tumcampusapp/utils/ThemedTimePickerDialog.kt
+++ b/app/src/main/java/de/tum/in/tumcampusapp/utils/ThemedTimePickerDialog.kt
@@ -6,8 +6,8 @@ import androidx.appcompat.app.AlertDialog
 import androidx.core.content.ContextCompat
 import de.tum.`in`.tumcampusapp.R
 
-class ThemedTimePickerDialog(context:Context, listener:OnTimeSetListener, hourOfDay:Int, minute:Int) :
-        TimePickerDialog(context,listener,hourOfDay,minute,true) {
+class ThemedTimePickerDialog(context: Context, listener: OnTimeSetListener, hourOfDay: Int, minute: Int) :
+        TimePickerDialog(context, listener, hourOfDay, minute, true) {
     override fun show() {
         window?.setBackgroundDrawableResource(R.drawable.rounded_corners_background)
         setOnShowListener {

--- a/app/src/main/java/de/tum/in/tumcampusapp/utils/ThemedTimePickerDialog.kt
+++ b/app/src/main/java/de/tum/in/tumcampusapp/utils/ThemedTimePickerDialog.kt
@@ -1,0 +1,19 @@
+package de.tum.`in`.tumcampusapp.utils
+
+import android.app.TimePickerDialog
+import android.content.Context
+import androidx.appcompat.app.AlertDialog
+import androidx.core.content.ContextCompat
+import de.tum.`in`.tumcampusapp.R
+
+class ThemedTimePickerDialog(context:Context, listener:OnTimeSetListener, hourOfDay:Int, minute:Int) :
+        TimePickerDialog(context,listener,hourOfDay,minute,true) {
+    override fun show() {
+        window?.setBackgroundDrawableResource(R.drawable.rounded_corners_background)
+        setOnShowListener {
+            getButton(AlertDialog.BUTTON_POSITIVE)?.setTextColor(ContextCompat.getColor(context, R.color.text_primary))
+            getButton(AlertDialog.BUTTON_NEGATIVE)?.setTextColor(ContextCompat.getColor(context, R.color.text_primary))
+        }
+        return super.show()
+    }
+}


### PR DESCRIPTION

## Issue

This fixes the following issue(s):
- Resolves: The Ok and Cancel Buttons in the Date- and TimePicker in the create-event view were not really visible in light-mode

## Screenshot
| Before  | After |
| ------------- | ------------- |
| ![grafik](https://user-images.githubusercontent.com/109673982/225319808-f8d4e224-6886-4b76-b41a-ba99e4b658cb.png)| ![grafik](https://user-images.githubusercontent.com/109673982/225317599-5498ab00-4022-484e-98f5-9ea0d7d0e7e2.png) |
| ![grafik](https://user-images.githubusercontent.com/109673982/225319953-97afa313-69bf-49a6-a91a-d207d4916837.png) |  ![grafik](https://user-images.githubusercontent.com/109673982/225317730-6ae5014a-c6ad-4adc-864f-de597cf455e7.png)|
## Why this is useful for all students
You can see the buttons better

