### PR TITLE
Fix issue #1585

### DIFF
--- a/app/src/main/java/de/tum/in/tumcampusapp/component/notifications/overview/NotificationOverviewActivity.kt
+++ b/app/src/main/java/de/tum/in/tumcampusapp/component/notifications/overview/NotificationOverviewActivity.kt
@@ -21,10 +21,11 @@ class NotificationOverviewActivity : BaseActivity(R.layout.activity_notification
 
         binding = ActivityNotificationOverviewBinding.inflate(layoutInflater)
         setContentView(binding.root)
-        setSupportActionBar(binding.toolbarInformation.toolbar)
+        setSupportActionBar(binding.toolbarNotificationOverview.toolbar)
         supportActionBar?.apply {
             setDisplayHomeAsUpEnabled(true)
             setDisplayShowHomeEnabled(true)
+            setTitle(R.string.notification_overview)
         }
 
         // get currently active notifications

--- a/app/src/main/java/de/tum/in/tumcampusapp/component/tumui/feedback/FeedbackActivity.kt
+++ b/app/src/main/java/de/tum/in/tumcampusapp/component/tumui/feedback/FeedbackActivity.kt
@@ -46,6 +46,7 @@ class FeedbackActivity : BaseActivity(R.layout.activity_feedback), FeedbackContr
         supportActionBar?.apply {
             setDisplayHomeAsUpEnabled(true)
             setDisplayShowHomeEnabled(true)
+            setTitle(R.string.feedback)
         }
 
         val lrzId = Utils.getSetting(this, Const.LRZ_ID, "")

--- a/app/src/main/java/de/tum/in/tumcampusapp/component/tumui/lectures/activity/LectureDetailsActivity.kt
+++ b/app/src/main/java/de/tum/in/tumcampusapp/component/tumui/lectures/activity/LectureDetailsActivity.kt
@@ -43,6 +43,7 @@ class LectureDetailsActivity : ActivityForAccessingTumOnline<LectureDetailsRespo
         supportActionBar?.apply {
             setDisplayHomeAsUpEnabled(true)
             setDisplayShowHomeEnabled(true)
+            setTitle(R.string.lectures_information)
         }
 
         binding.appointmentsButton.setOnClickListener {

--- a/app/src/main/java/de/tum/in/tumcampusapp/component/tumui/lectures/activity/LecturesAppointmentsActivity.kt
+++ b/app/src/main/java/de/tum/in/tumcampusapp/component/tumui/lectures/activity/LecturesAppointmentsActivity.kt
@@ -34,6 +34,7 @@ class LecturesAppointmentsActivity : ActivityForAccessingTumOnline<LectureAppoin
         supportActionBar?.apply {
             setDisplayHomeAsUpEnabled(true)
             setDisplayShowHomeEnabled(true)
+            setTitle(R.string.lectures_appointments)
         }
 
         supportActionBar?.setDisplayHomeAsUpEnabled(true)

--- a/app/src/main/java/de/tum/in/tumcampusapp/component/tumui/person/PersonDetailsActivity.kt
+++ b/app/src/main/java/de/tum/in/tumcampusapp/component/tumui/person/PersonDetailsActivity.kt
@@ -40,6 +40,7 @@ class PersonDetailsActivity : ActivityForAccessingTumOnline<Employee>(R.layout.a
         supportActionBar?.apply {
             setDisplayHomeAsUpEnabled(true)
             setDisplayShowHomeEnabled(true)
+            setTitle(R.string.person_information)
         }
 
         val person = intent.extras?.getSerializable(PERSON_OBJECT) as? Person

--- a/app/src/main/java/de/tum/in/tumcampusapp/component/ui/cafeteria/activity/CafeteriaNotificationSettingsActivity.kt
+++ b/app/src/main/java/de/tum/in/tumcampusapp/component/ui/cafeteria/activity/CafeteriaNotificationSettingsActivity.kt
@@ -28,6 +28,7 @@ class CafeteriaNotificationSettingsActivity : BaseActivity(R.layout.activity_caf
         supportActionBar?.apply {
             setDisplayHomeAsUpEnabled(true)
             setDisplayShowHomeEnabled(true)
+            setTitle(R.string.cafeteria_notification_settings)
         }
 
         val layoutManager = LinearLayoutManager(this)

--- a/app/src/main/java/de/tum/in/tumcampusapp/component/ui/overview/InformationActivity.kt
+++ b/app/src/main/java/de/tum/in/tumcampusapp/component/ui/overview/InformationActivity.kt
@@ -42,6 +42,7 @@ class InformationActivity : BaseActivity(R.layout.activity_information) {
         supportActionBar?.apply {
             setDisplayHomeAsUpEnabled(true)
             setDisplayShowHomeEnabled(true)
+            setTitle(R.string.about_tca)
         }
 
         binding.buttonFacebook.setOnClickListener {

--- a/app/src/main/res/layout/activity_notification_overview.xml
+++ b/app/src/main/res/layout/activity_notification_overview.xml
@@ -11,7 +11,7 @@
         android:layout_height="match_parent"
         android:orientation="vertical">
 
-        <include layout="@layout/toolbar" android:id="@+id/toolbar_information"/>
+        <include layout="@layout/toolbar" android:id="@+id/toolbar_notification_overview"/>
 
         <se.emilsjolander.stickylistheaders.StickyListHeadersListView
             android:id="@+id/notificationsListView"


### PR DESCRIPTION
## Issue

This fixes the following issue(s):
- Resolves: #1585

## Description Issue
Some titles of activites are in the wrong language. I suspect these titles are in the system language and not in the app language because it only happens with titles set directly in the manifest file and not programmaticly. Also it only happens for Activites setting up their own SupportActionBar as the Eduroam activity has a correct title but it is only defined in the manifest file.

## Description Solution
The solution is pretty straightforward and simply sets the title in the same place where the SupportActionBar is set up. This triggers the app to update the title to the correct language version.

## Remarks Solution
I believe that using [android:localeConfig](https://developer.android.com/guide/topics/resources/app-languages#impl-overview) would most likely also solve the Issue as the main reason for the issue is the difference between system language and app language which as far as I think localConfig would solve. Also it would allow the system to see and change the language of the app giving the user the freedom to edit app languages through the system settings. But localConfig is a really new feature (SDK 33) needing a never gradle plugin version than we are currently using. Also I was not able to run it with our current configuration so this would need to be updated as well. I suggest keeping this option in mind and implementing it given it has been established more.

## Why this is useful for all students
Fixes titles of activities being in the wrong language.


