### PR TITLE
Fixes the CardView customization mentioned in #1582

### DIFF
--- a/app/src/main/java/de/tum/in/tumcampusapp/component/other/settings/SettingsFragment.kt
+++ b/app/src/main/java/de/tum/in/tumcampusapp/component/other/settings/SettingsFragment.kt
@@ -47,7 +47,7 @@ import java.util.concurrent.ExecutionException
 import javax.inject.Inject
 
 class SettingsFragment : PreferenceFragmentCompat(), Preference.OnPreferenceClickListener,
-        SharedPreferences.OnSharedPreferenceChangeListener {
+    SharedPreferences.OnSharedPreferenceChangeListener {
 
     private val compositeDisposable = CompositeDisposable()
 
@@ -92,6 +92,7 @@ class SettingsFragment : PreferenceFragmentCompat(), Preference.OnPreferenceClic
                 setSummary("silent_mode_set_to")
                 setSummary("background_mode_set_to")
             }
+
             "card_cafeteria" -> {
                 setSummary("card_cafeteria_default_G")
                 setSummary("card_cafeteria_default_K")
@@ -99,11 +100,13 @@ class SettingsFragment : PreferenceFragmentCompat(), Preference.OnPreferenceClic
                 setSummary("card_role")
                 initCafeteriaCardSelections()
             }
+
             "card_mvv" -> {
                 setSummary("card_stations_default_G")
                 setSummary("card_stations_default_C")
                 setSummary("card_stations_default_K")
             }
+
             "card_eduroam" -> {
                 findPreference(SETUP_EDUROAM).onPreferenceClickListener = this
             }
@@ -140,11 +143,11 @@ class SettingsFragment : PreferenceFragmentCompat(), Preference.OnPreferenceClic
         url: String
     ) {
         compositeDisposable += Single
-                .fromCallable { Picasso.get().load(url).get() }
-                .subscribeOn(Schedulers.io())
-                .map { BitmapDrawable(resources, it) }
-                .observeOn(AndroidSchedulers.mainThread())
-                .subscribe(preference::setIcon, Utils::log)
+            .fromCallable { Picasso.get().load(url).get() }
+            .subscribeOn(Schedulers.io())
+            .map { BitmapDrawable(resources, it) }
+            .observeOn(AndroidSchedulers.mainThread())
+            .subscribe(preference::setIcon, Utils::log)
     }
 
     /**
@@ -223,16 +226,16 @@ class SettingsFragment : PreferenceFragmentCompat(), Preference.OnPreferenceClic
         // restart app after visibility of card changed
         val cardTypesPrefNames = CardManager.CardTypes.values().map { context?.getString(it.showCardPreferenceStringRes) }
         // restart when visibility changed
-        if (key in cardTypesPrefNames){
+        if (key in cardTypesPrefNames) {
             (activity as SettingsActivity).restartApp()
         }
     }
 
     private fun initCafeteriaCardSelections() {
         val cafeterias = cafeteriaLocalRepository
-                .getAllCafeterias()
-                .blockingFirst()
-                .sortedBy { it.name }
+            .getAllCafeterias()
+            .blockingFirst()
+            .sortedBy { it.name }
 
         val cafeteriaByLocationName = getString(R.string.settings_cafeteria_depending_on_location)
         val cafeteriaNames = listOf(cafeteriaByLocationName) + cafeterias.map { it.name }
@@ -267,11 +270,11 @@ class SettingsFragment : PreferenceFragmentCompat(), Preference.OnPreferenceClic
             preference.setSummary(R.string.settings_no_location_selected)
         } else {
             preference.summary = values
-                    .map { preference.findIndexOfValue(it) }
-                    .map { preference.entries[it] }
-                    .map { it.toString() }
-                    .sorted()
-                    .joinToString(", ")
+                .map { preference.findIndexOfValue(it) }
+                .map { preference.entries[it] }
+                .map { it.toString() }
+                .sorted()
+                .joinToString(", ")
         }
     }
 

--- a/app/src/main/java/de/tum/in/tumcampusapp/component/other/settings/SettingsFragment.kt
+++ b/app/src/main/java/de/tum/in/tumcampusapp/component/other/settings/SettingsFragment.kt
@@ -29,6 +29,7 @@ import de.tum.`in`.tumcampusapp.component.ui.cafeteria.repository.CafeteriaLocal
 import de.tum.`in`.tumcampusapp.component.ui.eduroam.SetupEduroamActivity
 import de.tum.`in`.tumcampusapp.component.ui.news.NewsController
 import de.tum.`in`.tumcampusapp.component.ui.onboarding.StartupActivity
+import de.tum.`in`.tumcampusapp.component.ui.overview.CardManager
 import de.tum.`in`.tumcampusapp.database.TcaDb
 import de.tum.`in`.tumcampusapp.di.injector
 import de.tum.`in`.tumcampusapp.service.SilenceWorker
@@ -217,6 +218,12 @@ class SettingsFragment : PreferenceFragmentCompat(), Preference.OnPreferenceClic
 
         // restart app after language change
         if (key == "language_preference" && activity != null) {
+            (activity as SettingsActivity).restartApp()
+        }
+        // restart app after visibility of card changed
+        val cardTypesPrefNames = CardManager.CardTypes.values().map { context?.getString(it.showCardPreferenceStringRes) }
+        // restart when visibility changed
+        if (key in cardTypesPrefNames){
             (activity as SettingsActivity).restartApp()
         }
     }

--- a/app/src/main/java/de/tum/in/tumcampusapp/component/tumui/calendar/NextLectureCard.kt
+++ b/app/src/main/java/de/tum/in/tumcampusapp/component/tumui/calendar/NextLectureCard.kt
@@ -14,7 +14,7 @@ import de.tum.`in`.tumcampusapp.component.ui.overview.card.CardViewHolder
 import org.joda.time.DateTime
 import java.util.*
 
-class NextLectureCard(context: Context) : Card(CardManager.CARD_NEXT_LECTURE, context, "card_next_lecture") {
+class NextLectureCard(context: Context) : Card(CardManager.CardTypes.NEXT_LECTURE, context, "card_next_lecture") {
 
     private val calendarController: CalendarController = CalendarController(context)
 

--- a/app/src/main/java/de/tum/in/tumcampusapp/component/tumui/calendar/NextLectureCard.kt
+++ b/app/src/main/java/de/tum/in/tumcampusapp/component/tumui/calendar/NextLectureCard.kt
@@ -14,7 +14,7 @@ import de.tum.`in`.tumcampusapp.component.ui.overview.card.CardViewHolder
 import org.joda.time.DateTime
 import java.util.*
 
-class NextLectureCard(context: Context) : Card(CardManager.CardTypes.NEXT_LECTURE, context, "card_next_lecture") {
+class NextLectureCard(context: Context) : Card(CardManager.CardTypes.NEXT_LECTURE, context) {
 
     private val calendarController: CalendarController = CalendarController(context)
 

--- a/app/src/main/java/de/tum/in/tumcampusapp/component/tumui/tutionfees/TuitionFeesCard.kt
+++ b/app/src/main/java/de/tum/in/tumcampusapp/component/tumui/tutionfees/TuitionFeesCard.kt
@@ -24,7 +24,7 @@ import org.joda.time.format.DateTimeFormat
 class TuitionFeesCard(
     context: Context,
     private val tuition: Tuition
-) : Card(CardManager.CardTypes.TUITION_FEE, context, "card_tuition_fee") {
+) : Card(CardManager.CardTypes.TUITION_FEE, context) {
 
     override val optionsMenuResId: Int
         get() = R.menu.card_popup_menu

--- a/app/src/main/java/de/tum/in/tumcampusapp/component/tumui/tutionfees/TuitionFeesCard.kt
+++ b/app/src/main/java/de/tum/in/tumcampusapp/component/tumui/tutionfees/TuitionFeesCard.kt
@@ -24,7 +24,7 @@ import org.joda.time.format.DateTimeFormat
 class TuitionFeesCard(
     context: Context,
     private val tuition: Tuition
-) : Card(CardManager.CARD_TUITION_FEE, context, "card_tuition_fee") {
+) : Card(CardManager.CardTypes.TUITION_FEE, context, "card_tuition_fee") {
 
     override val optionsMenuResId: Int
         get() = R.menu.card_popup_menu

--- a/app/src/main/java/de/tum/in/tumcampusapp/component/ui/cafeteria/CafeteriaMenuCard.kt
+++ b/app/src/main/java/de/tum/in/tumcampusapp/component/ui/cafeteria/CafeteriaMenuCard.kt
@@ -22,7 +22,8 @@ import java.util.*
 /**
  * Card that shows the cafeteria menu
  */
-class CafeteriaMenuCard(context: Context, private val cafeteria: CafeteriaWithMenus) : Card(CardManager.CardTypes.CAFETERIA, context, "card_cafeteria") {
+class CafeteriaMenuCard(context: Context, private val cafeteria: CafeteriaWithMenus) :
+    Card(CardManager.CardTypes.CAFETERIA, context, "card_cafeteria") {
 
     override val optionsMenuResId: Int
         get() = R.menu.card_popup_menu

--- a/app/src/main/java/de/tum/in/tumcampusapp/component/ui/cafeteria/CafeteriaMenuCard.kt
+++ b/app/src/main/java/de/tum/in/tumcampusapp/component/ui/cafeteria/CafeteriaMenuCard.kt
@@ -22,7 +22,7 @@ import java.util.*
 /**
  * Card that shows the cafeteria menu
  */
-class CafeteriaMenuCard(context: Context, private val cafeteria: CafeteriaWithMenus) : Card(CardManager.CARD_CAFETERIA, context, "card_cafeteria") {
+class CafeteriaMenuCard(context: Context, private val cafeteria: CafeteriaWithMenus) : Card(CardManager.CardTypes.CAFETERIA, context, "card_cafeteria") {
 
     override val optionsMenuResId: Int
         get() = R.menu.card_popup_menu

--- a/app/src/main/java/de/tum/in/tumcampusapp/component/ui/cafeteria/CafeteriaMenuCard.kt
+++ b/app/src/main/java/de/tum/in/tumcampusapp/component/ui/cafeteria/CafeteriaMenuCard.kt
@@ -23,7 +23,7 @@ import java.util.*
  * Card that shows the cafeteria menu
  */
 class CafeteriaMenuCard(context: Context, private val cafeteria: CafeteriaWithMenus) :
-    Card(CardManager.CardTypes.CAFETERIA, context, "card_cafeteria") {
+    Card(CardManager.CardTypes.CAFETERIA, context) {
 
     override val optionsMenuResId: Int
         get() = R.menu.card_popup_menu

--- a/app/src/main/java/de/tum/in/tumcampusapp/component/ui/eduroam/EduroamCard.kt
+++ b/app/src/main/java/de/tum/in/tumcampusapp/component/ui/eduroam/EduroamCard.kt
@@ -23,7 +23,7 @@ import org.jetbrains.anko.wifiManager
 /**
  * Card that can start [SetupEduroamActivity]
  */
-class EduroamCard(context: Context) : Card(CardManager.CardTypes.EDUROAM, context, "card_eduroam") {
+class EduroamCard(context: Context) : Card(CardManager.CardTypes.EDUROAM, context) {
 
     override val optionsMenuResId: Int
         get() = R.menu.card_popup_menu

--- a/app/src/main/java/de/tum/in/tumcampusapp/component/ui/eduroam/EduroamCard.kt
+++ b/app/src/main/java/de/tum/in/tumcampusapp/component/ui/eduroam/EduroamCard.kt
@@ -57,7 +57,6 @@ class EduroamCard(context: Context) : Card(CardManager.CardTypes.EDUROAM, contex
 
     override fun discard(editor: SharedPreferences.Editor) {
         editor.putBoolean("card_eduroam_start", false)
-            .apply()
     }
 
     override fun getId(): Int {

--- a/app/src/main/java/de/tum/in/tumcampusapp/component/ui/eduroam/EduroamCard.kt
+++ b/app/src/main/java/de/tum/in/tumcampusapp/component/ui/eduroam/EduroamCard.kt
@@ -38,10 +38,10 @@ class EduroamCard(context: Context) : Card(CardManager.CardTypes.EDUROAM, contex
     override fun shouldShow(prefs: SharedPreferences): Boolean {
         // Check if WiFi is turned on at all, as we cannot say if it was configured if it is off
         val wifiManager = context.wifiManager
-        return (wifiManager.isWifiEnabled
-            && EduroamController.getEduroamConfig(context) == null
-            && eduroamAvailable(wifiManager)
-            && prefs.getBoolean("card_eduroam_start", true))
+        return (wifiManager.isWifiEnabled &&
+            EduroamController.getEduroamConfig(context) == null &&
+            eduroamAvailable(wifiManager) &&
+            prefs.getBoolean("card_eduroam_start", true))
     }
 
     private fun eduroamAvailable(wifi: WifiManager): Boolean {

--- a/app/src/main/java/de/tum/in/tumcampusapp/component/ui/eduroam/EduroamCard.kt
+++ b/app/src/main/java/de/tum/in/tumcampusapp/component/ui/eduroam/EduroamCard.kt
@@ -7,7 +7,6 @@ import android.content.Intent
 import android.content.SharedPreferences
 import android.content.pm.PackageManager.PERMISSION_GRANTED
 import android.net.wifi.WifiManager
-import android.preference.PreferenceManager
 import android.view.LayoutInflater
 import android.view.ViewGroup
 import androidx.core.content.ContextCompat.checkSelfPermission
@@ -24,7 +23,7 @@ import org.jetbrains.anko.wifiManager
 /**
  * Card that can start [SetupEduroamActivity]
  */
-class EduroamCard(context: Context) : Card(CardManager.CARD_EDUROAM, context, "card_eduroam") {
+class EduroamCard(context: Context) : Card(CardManager.CardTypes.EDUROAM, context, "card_eduroam") {
 
     override val optionsMenuResId: Int
         get() = R.menu.card_popup_menu
@@ -39,7 +38,10 @@ class EduroamCard(context: Context) : Card(CardManager.CARD_EDUROAM, context, "c
     override fun shouldShow(prefs: SharedPreferences): Boolean {
         // Check if WiFi is turned on at all, as we cannot say if it was configured if it is off
         val wifiManager = context.wifiManager
-        return (wifiManager.isWifiEnabled && EduroamController.getEduroamConfig(context) == null && eduroamAvailable(wifiManager))
+        return (wifiManager.isWifiEnabled
+            && EduroamController.getEduroamConfig(context) == null
+            && eduroamAvailable(wifiManager)
+            && prefs.getBoolean("card_eduroam_start", true))
     }
 
     private fun eduroamAvailable(wifi: WifiManager): Boolean {
@@ -54,9 +56,8 @@ class EduroamCard(context: Context) : Card(CardManager.CARD_EDUROAM, context, "c
     }
 
     override fun discard(editor: SharedPreferences.Editor) {
-        val prefs = PreferenceManager.getDefaultSharedPreferences(context)
-        prefs.edit().putBoolean("card_eduroam_start", false)
-                .apply()
+        editor.putBoolean("card_eduroam_start", false)
+            .apply()
     }
 
     override fun getId(): Int {

--- a/app/src/main/java/de/tum/in/tumcampusapp/component/ui/eduroam/EduroamFixCard.kt
+++ b/app/src/main/java/de/tum/in/tumcampusapp/component/ui/eduroam/EduroamFixCard.kt
@@ -26,7 +26,7 @@ import java.util.regex.Pattern
 
 class EduroamFixCard(
     context: Context
-) : Card(CardManager.CARD_EDUROAM_FIX, context, "card_eduroam_fix_start") {
+) : Card(CardManager.CardTypes.EDUROAM_FIX, context, "card_eduroam_fix_start") {
 
     private val errors: MutableList<String> = ArrayList()
     private lateinit var eduroam: WifiConfiguration
@@ -72,11 +72,11 @@ class EduroamFixCard(
         // Check if wifi is turned on at all, as we cannot say if it was configured if its off
         return if (!context.wifiManager.isWifiEnabled) {
             false
-        } else !isConfigValid()
+        } else !isConfigValid() && prefs.getBoolean("card_eduroam_fix_start", true)
     }
 
     override fun discard(editor: SharedPreferences.Editor) {
-        context.defaultSharedPreferences.edit().putBoolean("card_eduroam_fix_start", false).apply()
+        editor.putBoolean("card_eduroam_fix_start", false)
     }
 
     override fun getId(): Int {

--- a/app/src/main/java/de/tum/in/tumcampusapp/component/ui/eduroam/EduroamFixCard.kt
+++ b/app/src/main/java/de/tum/in/tumcampusapp/component/ui/eduroam/EduroamFixCard.kt
@@ -19,14 +19,13 @@ import de.tum.`in`.tumcampusapp.component.ui.overview.card.Card
 import de.tum.`in`.tumcampusapp.component.ui.overview.card.CardViewHolder
 import de.tum.`in`.tumcampusapp.utils.Const
 import de.tum.`in`.tumcampusapp.utils.Utils
-import org.jetbrains.anko.defaultSharedPreferences
 import org.jetbrains.anko.wifiManager
 import java.util.*
 import java.util.regex.Pattern
 
 class EduroamFixCard(
     context: Context
-) : Card(CardManager.CardTypes.EDUROAM_FIX, context, "card_eduroam_fix_start") {
+) : Card(CardManager.CardTypes.EDUROAM_FIX, context) {
 
     private val errors: MutableList<String> = ArrayList()
     private lateinit var eduroam: WifiConfiguration

--- a/app/src/main/java/de/tum/in/tumcampusapp/component/ui/news/NewsCard.kt
+++ b/app/src/main/java/de/tum/in/tumcampusapp/component/ui/news/NewsCard.kt
@@ -21,7 +21,7 @@ open class NewsCard @JvmOverloads constructor(
     context: Context,
     val news: News,
     type: CardManager.CardTypes = CardManager.CardTypes.NEWS
-) : Card(type, context, "card_news") {
+) : Card(type, context) {
 
     override val optionsMenuResId: Int
         get() = R.menu.card_popup_menu

--- a/app/src/main/java/de/tum/in/tumcampusapp/component/ui/news/NewsCard.kt
+++ b/app/src/main/java/de/tum/in/tumcampusapp/component/ui/news/NewsCard.kt
@@ -20,7 +20,7 @@ import org.joda.time.DateTime
 open class NewsCard @JvmOverloads constructor(
     context: Context,
     val news: News,
-    type: Int = CardManager.CARD_NEWS
+    type: CardManager.CardTypes = CardManager.CardTypes.NEWS
 ) : Card(type, context, "card_news") {
 
     override val optionsMenuResId: Int

--- a/app/src/main/java/de/tum/in/tumcampusapp/component/ui/news/NewsViewHolder.kt
+++ b/app/src/main/java/de/tum/in/tumcampusapp/component/ui/news/NewsViewHolder.kt
@@ -93,6 +93,7 @@ class NewsViewHolder(
     private fun bindNews(newsItem: News) {
         val imageUrl = newsItem.image
         if (imageUrl.isNotEmpty()) {
+            imageView?.visibility = VISIBLE
             loadNewsImage(imageUrl)
         } else {
             imageView?.visibility = GONE

--- a/app/src/main/java/de/tum/in/tumcampusapp/component/ui/news/TopNewsCard.kt
+++ b/app/src/main/java/de/tum/in/tumcampusapp/component/ui/news/TopNewsCard.kt
@@ -24,7 +24,7 @@ import org.jetbrains.anko.defaultSharedPreferences
 /**
  * Shows important news
  */
-class TopNewsCard(context: Context) : Card(CardManager.CardTypes.TOP_NEWS, context, "top_news") {
+class TopNewsCard(context: Context) : Card(CardManager.CardTypes.TOP_NEWS, context) {
     private lateinit var imageView: ImageView
     private lateinit var progress: ProgressBar
     private val topNewsStore: TopNewsStore

--- a/app/src/main/java/de/tum/in/tumcampusapp/component/ui/news/TopNewsCard.kt
+++ b/app/src/main/java/de/tum/in/tumcampusapp/component/ui/news/TopNewsCard.kt
@@ -24,7 +24,7 @@ import org.jetbrains.anko.defaultSharedPreferences
 /**
  * Shows important news
  */
-class TopNewsCard(context: Context) : Card(CardManager.CARD_TOP_NEWS, context, "top_news") {
+class TopNewsCard(context: Context) : Card(CardManager.CardTypes.TOP_NEWS, context, "top_news") {
     private lateinit var imageView: ImageView
     private lateinit var progress: ProgressBar
     private val topNewsStore: TopNewsStore

--- a/app/src/main/java/de/tum/in/tumcampusapp/component/ui/news/TopNewsStore.kt
+++ b/app/src/main/java/de/tum/in/tumcampusapp/component/ui/news/TopNewsStore.kt
@@ -62,7 +62,7 @@ class RealTopNewsStore @Inject constructor(
         }
 
         val displayUntil = sharedPrefs.getString(Const.NEWS_ALERT_SHOW_UNTIL, "")!!
-        if(displayUntil.isEmpty()){
+        if (displayUntil.isEmpty()) {
             return null
         }
         val until: DateTime? = DateTimeUtils.parseIsoDateWithMillis(displayUntil)

--- a/app/src/main/java/de/tum/in/tumcampusapp/component/ui/news/TopNewsStore.kt
+++ b/app/src/main/java/de/tum/in/tumcampusapp/component/ui/news/TopNewsStore.kt
@@ -62,6 +62,9 @@ class RealTopNewsStore @Inject constructor(
         }
 
         val displayUntil = sharedPrefs.getString(Const.NEWS_ALERT_SHOW_UNTIL, "")!!
+        if(displayUntil.isEmpty()){
+            return null
+        }
         val until: DateTime? = DateTimeUtils.parseIsoDateWithMillis(displayUntil)
         if (until == null || until.isBeforeNow) {
             return null

--- a/app/src/main/java/de/tum/in/tumcampusapp/component/ui/onboarding/LoginPromptCard.kt
+++ b/app/src/main/java/de/tum/in/tumcampusapp/component/ui/onboarding/LoginPromptCard.kt
@@ -19,14 +19,19 @@ import de.tum.`in`.tumcampusapp.utils.Utils
  */
 class LoginPromptCard(context: Context) : Card(CardManager.CARD_LOGIN, context, "card_login") {
 
+    private val SHOW_LOGIN = "show_login"
+
     public override fun discard(editor: SharedPreferences.Editor) {
-        Utils.setSetting(context, CardManager.SHOW_LOGIN, false)
+        //Utils.setSetting(context, CardManager.SHOW_LOGIN, false)
+        editor.putBoolean(SHOW_LOGIN, false)
     }
 
     override fun shouldShow(prefs: SharedPreferences): Boolean {
         // show on top as long as user hasn't swiped it away and isn't connected to TUMonline
-        return Utils.getSettingBool(context, CardManager.SHOW_LOGIN, true) &&
-            Utils.getSetting(context, Const.LRZ_ID, "").isEmpty()
+        //return Utils.getSettingBool(context, CardManager.SHOW_LOGIN, true) &&
+        //    Utils.getSetting(context, Const.LRZ_ID, "").isEmpty()
+        return prefs.getBoolean(SHOW_LOGIN, true) &&
+            prefs.getString(Const.LRZ_ID, "").isNullOrEmpty()
     }
 
     override fun getId(): Int {

--- a/app/src/main/java/de/tum/in/tumcampusapp/component/ui/onboarding/LoginPromptCard.kt
+++ b/app/src/main/java/de/tum/in/tumcampusapp/component/ui/onboarding/LoginPromptCard.kt
@@ -16,7 +16,7 @@ import de.tum.`in`.tumcampusapp.utils.Const
  * Card that prompts the user to login to TUMonline since we don't show the wizard after the first launch anymore.
  * It will be shown until it is swiped away for the first time.
  */
-class LoginPromptCard(context: Context) : Card(CardManager.CardTypes.LOGIN, context, "card_login") {
+class LoginPromptCard(context: Context) : Card(CardManager.CardTypes.LOGIN, context) {
 
     private val SHOW_LOGIN = "show_login"
 

--- a/app/src/main/java/de/tum/in/tumcampusapp/component/ui/onboarding/LoginPromptCard.kt
+++ b/app/src/main/java/de/tum/in/tumcampusapp/component/ui/onboarding/LoginPromptCard.kt
@@ -11,6 +11,7 @@ import de.tum.`in`.tumcampusapp.component.ui.overview.CardManager
 import de.tum.`in`.tumcampusapp.component.ui.overview.card.Card
 import de.tum.`in`.tumcampusapp.component.ui.overview.card.CardViewHolder
 import de.tum.`in`.tumcampusapp.utils.Const
+import de.tum.`in`.tumcampusapp.utils.Utils
 
 /**
  * Card that prompts the user to login to TUMonline since we don't show the wizard after the first launch anymore.
@@ -27,7 +28,7 @@ class LoginPromptCard(context: Context) : Card(CardManager.CardTypes.LOGIN, cont
     override fun shouldShow(prefs: SharedPreferences): Boolean {
         // show on top as long as user hasn't swiped it away and isn't connected to TUMonline
         return prefs.getBoolean(SHOW_LOGIN, true) &&
-            prefs.getString(Const.LRZ_ID, "").isNullOrEmpty()
+            Utils.getSetting(context, Const.LRZ_ID, "").isEmpty()
     }
 
     override fun getId(): Int {

--- a/app/src/main/java/de/tum/in/tumcampusapp/component/ui/onboarding/LoginPromptCard.kt
+++ b/app/src/main/java/de/tum/in/tumcampusapp/component/ui/onboarding/LoginPromptCard.kt
@@ -19,15 +19,15 @@ import de.tum.`in`.tumcampusapp.utils.Utils
  */
 class LoginPromptCard(context: Context) : Card(CardManager.CardTypes.LOGIN, context) {
 
-    private val SHOW_LOGIN = "show_login"
+    private val showLogin = "show_login"
 
     public override fun discard(editor: SharedPreferences.Editor) {
-        editor.putBoolean(SHOW_LOGIN, false)
+        editor.putBoolean(showLogin, false)
     }
 
     override fun shouldShow(prefs: SharedPreferences): Boolean {
         // show on top as long as user hasn't swiped it away and isn't connected to TUMonline
-        return prefs.getBoolean(SHOW_LOGIN, true) &&
+        return prefs.getBoolean(showLogin, true) &&
             Utils.getSetting(context, Const.LRZ_ID, "").isEmpty()
     }
 

--- a/app/src/main/java/de/tum/in/tumcampusapp/component/ui/onboarding/LoginPromptCard.kt
+++ b/app/src/main/java/de/tum/in/tumcampusapp/component/ui/onboarding/LoginPromptCard.kt
@@ -11,25 +11,21 @@ import de.tum.`in`.tumcampusapp.component.ui.overview.CardManager
 import de.tum.`in`.tumcampusapp.component.ui.overview.card.Card
 import de.tum.`in`.tumcampusapp.component.ui.overview.card.CardViewHolder
 import de.tum.`in`.tumcampusapp.utils.Const
-import de.tum.`in`.tumcampusapp.utils.Utils
 
 /**
  * Card that prompts the user to login to TUMonline since we don't show the wizard after the first launch anymore.
  * It will be shown until it is swiped away for the first time.
  */
-class LoginPromptCard(context: Context) : Card(CardManager.CARD_LOGIN, context, "card_login") {
+class LoginPromptCard(context: Context) : Card(CardManager.CardTypes.LOGIN, context, "card_login") {
 
     private val SHOW_LOGIN = "show_login"
 
     public override fun discard(editor: SharedPreferences.Editor) {
-        //Utils.setSetting(context, CardManager.SHOW_LOGIN, false)
         editor.putBoolean(SHOW_LOGIN, false)
     }
 
     override fun shouldShow(prefs: SharedPreferences): Boolean {
         // show on top as long as user hasn't swiped it away and isn't connected to TUMonline
-        //return Utils.getSettingBool(context, CardManager.SHOW_LOGIN, true) &&
-        //    Utils.getSetting(context, Const.LRZ_ID, "").isEmpty()
         return prefs.getBoolean(SHOW_LOGIN, true) &&
             prefs.getString(Const.LRZ_ID, "").isNullOrEmpty()
     }

--- a/app/src/main/java/de/tum/in/tumcampusapp/component/ui/overview/CardAdapter.kt
+++ b/app/src/main/java/de/tum/in/tumcampusapp/component/ui/overview/CardAdapter.kt
@@ -27,20 +27,20 @@ class CardAdapter(private val interactionListener: CardInteractionListener) : Re
 
     override fun onCreateViewHolder(viewGroup: ViewGroup, viewType: Int): CardViewHolder {
         when (viewType) {
-            CardManager.CARD_CAFETERIA -> return CafeteriaMenuCard.inflateViewHolder(viewGroup, interactionListener)
-            CardManager.CARD_TUITION_FEE -> return TuitionFeesCard.inflateViewHolder(viewGroup, interactionListener)
-            CardManager.CARD_NEXT_LECTURE -> return NextLectureCard.inflateViewHolder(viewGroup, interactionListener)
-            CardManager.CARD_RESTORE -> return RestoreCard.inflateViewHolder(viewGroup, interactionListener)
-            CardManager.CARD_NO_INTERNET -> return NoInternetCard.inflateViewHolder(viewGroup, interactionListener)
-            CardManager.CARD_MVV -> return MVVCard.inflateViewHolder(viewGroup, interactionListener)
-            CardManager.CARD_NEWS, CardManager.CARD_NEWS_FILM -> return NewsCard.inflateViewHolder(viewGroup, viewType, interactionListener)
-            CardManager.CARD_EDUROAM -> return EduroamCard.inflateViewHolder(viewGroup, interactionListener)
-            CardManager.CARD_EDUROAM_FIX -> return EduroamFixCard.inflateViewHolder(viewGroup, interactionListener)
-            CardManager.CARD_SUPPORT -> return SupportCard.inflateViewHolder(viewGroup, interactionListener)
-            CardManager.CARD_LOGIN -> return LoginPromptCard.inflateViewHolder(viewGroup, interactionListener)
-            CardManager.CARD_TOP_NEWS -> return TopNewsCard.inflateViewHolder(viewGroup, interactionListener)
-            CardManager.CARD_EVENT -> return EventCard.inflateViewHolder(viewGroup, interactionListener)
-            CardManager.CARD_UPDATE_NOTE -> return UpdateNoteCard.inflateViewHolder(viewGroup, interactionListener)
+            CardManager.CardTypes.CAFETERIA.id -> return CafeteriaMenuCard.inflateViewHolder(viewGroup, interactionListener)
+            CardManager.CardTypes.TUITION_FEE.id -> return TuitionFeesCard.inflateViewHolder(viewGroup, interactionListener)
+            CardManager.CardTypes.NEXT_LECTURE.id -> return NextLectureCard.inflateViewHolder(viewGroup, interactionListener)
+            CardManager.CardTypes.RESTORE.id -> return RestoreCard.inflateViewHolder(viewGroup, interactionListener)
+            CardManager.CardTypes.NO_INTERNET.id -> return NoInternetCard.inflateViewHolder(viewGroup, interactionListener)
+            CardManager.CardTypes.MVV.id -> return MVVCard.inflateViewHolder(viewGroup, interactionListener)
+            CardManager.CardTypes.NEWS.id, CardManager.CardTypes.NEWS_FILM.id -> return NewsCard.inflateViewHolder(viewGroup, viewType, interactionListener)
+            CardManager.CardTypes.EDUROAM.id -> return EduroamCard.inflateViewHolder(viewGroup, interactionListener)
+            CardManager.CardTypes.EDUROAM_FIX.id -> return EduroamFixCard.inflateViewHolder(viewGroup, interactionListener)
+            CardManager.CardTypes.SUPPORT.id -> return SupportCard.inflateViewHolder(viewGroup, interactionListener)
+            CardManager.CardTypes.LOGIN.id -> return LoginPromptCard.inflateViewHolder(viewGroup, interactionListener)
+            CardManager.CardTypes.TOP_NEWS.id -> return TopNewsCard.inflateViewHolder(viewGroup, interactionListener)
+            CardManager.CardTypes.EVENT.id -> return EventCard.inflateViewHolder(viewGroup, interactionListener)
+            CardManager.CardTypes.UPDATE_NOTE.id -> return UpdateNoteCard.inflateViewHolder(viewGroup, interactionListener)
             else -> throw UnsupportedOperationException()
         }
     }
@@ -51,11 +51,11 @@ class CardAdapter(private val interactionListener: CardInteractionListener) : Re
         card.updateViewHolder(viewHolder)
     }
 
-    override fun getItemViewType(position: Int) = mItems[position].cardType
+    override fun getItemViewType(position: Int) = mItems[position].cardType.id
 
     override fun getItemId(position: Int): Long {
         val card = mItems[position]
-        return (card.cardType + (card.getId() shl 4)).toLong()
+        return (card.cardType.id + (card.getId() shl 4)).toLong()
     }
 
     override fun getItemCount() = mItems.size

--- a/app/src/main/java/de/tum/in/tumcampusapp/component/ui/overview/CardManager.kt
+++ b/app/src/main/java/de/tum/in/tumcampusapp/component/ui/overview/CardManager.kt
@@ -7,6 +7,7 @@ import de.tum.`in`.tumcampusapp.database.TcaDb
 import de.tum.`in`.tumcampusapp.utils.Const.CARD_POSITION_PREFERENCE_SUFFIX
 import de.tum.`in`.tumcampusapp.utils.Const.DISCARD_SETTINGS_START
 import de.tum.`in`.tumcampusapp.utils.Utils
+import org.jetbrains.anko.defaultSharedPreferences
 
 /**
  * Card manager, manages inserting, dismissing, updating and displaying of cards
@@ -14,12 +15,31 @@ import de.tum.`in`.tumcampusapp.utils.Utils
 object CardManager {
 
     const val SHOW_SUPPORT = "show_support"
-    const val SHOW_LOGIN = "show_login"
     const val SHOW_TOP_NEWS = "show_top_news"
 
     /**
      * Card typ constants
      */
+    enum class CardTypes(val id: Int) {
+        CAFETERIA(R.layout.card_cafeteria_menu),
+        TUITION_FEE(R.layout.card_tuition_fees),
+        NEXT_LECTURE(R.layout.card_next_lecture_item),
+        RESTORE(R.layout.card_restore),
+        NO_INTERNET(R.layout.card_no_internet),
+        MVV(R.layout.card_mvv),
+        NEWS(R.layout.card_news_item),
+        NEWS_FILM(R.layout.card_news_film_item),
+        EDUROAM(R.layout.card_eduroam),
+        CHAT(R.layout.card_chat_messages),
+        SUPPORT(R.layout.card_support),
+        LOGIN(R.layout.card_login_prompt),
+        EDUROAM_FIX(R.layout.card_eduroam_fix),
+        TOP_NEWS(R.layout.card_top_news),
+        EVENT(R.layout.card_events_item),
+        UPDATE_NOTE(R.layout.card_update_note)
+
+    }
+
     const val CARD_CAFETERIA = R.layout.card_cafeteria_menu
     const val CARD_TUITION_FEE = R.layout.card_tuition_fees
     const val CARD_NEXT_LECTURE = R.layout.card_next_lecture_item
@@ -41,14 +61,25 @@ object CardManager {
      * Resets dismiss settings for all cards
      */
     fun restoreCards(context: Context) {
-        context.getSharedPreferences(DISCARD_SETTINGS_START, 0)
+        CardTypes.values().forEach {
+            context.getSharedPreferences("CardPref" + it.id.toString(), Context.MODE_PRIVATE)
                 .edit()
+                // wipe completly
                 .clear()
+                //.putBoolean("shouldShow", true)
                 .apply()
+        }
+
+        println("HierHier" + "restored")
+
+        context.getSharedPreferences(DISCARD_SETTINGS_START, 0)
+            .edit()
+            .clear()
+            .apply()
 
         TcaDb.getInstance(context)
-                .newsDao()
-                .restoreAllNews()
+            .newsDao()
+            .restoreAllNews()
 
         Utils.setSetting(context, SHOW_TOP_NEWS, true)
         restoreCardPositions(context)

--- a/app/src/main/java/de/tum/in/tumcampusapp/component/ui/overview/CardManager.kt
+++ b/app/src/main/java/de/tum/in/tumcampusapp/component/ui/overview/CardManager.kt
@@ -1,11 +1,11 @@
 package de.tum.`in`.tumcampusapp.component.ui.overview
 
 import android.content.Context
-import android.preference.PreferenceManager
 import de.tum.`in`.tumcampusapp.R
 import de.tum.`in`.tumcampusapp.database.TcaDb
 import de.tum.`in`.tumcampusapp.utils.Const.CARD_POSITION_PREFERENCE_SUFFIX
 import de.tum.`in`.tumcampusapp.utils.Utils
+import org.jetbrains.anko.defaultSharedPreferences
 
 /**
  * Card manager, manages inserting, dismissing, updating and displaying of cards
@@ -57,7 +57,7 @@ object CardManager {
     }
 
     private fun restoreCardPositions(context: Context) {
-        val preferences = PreferenceManager.getDefaultSharedPreferences(context)
+        val preferences = context.defaultSharedPreferences
         val editor = preferences.edit()
 
         for (s in preferences.all.keys) {

--- a/app/src/main/java/de/tum/in/tumcampusapp/component/ui/overview/CardManager.kt
+++ b/app/src/main/java/de/tum/in/tumcampusapp/component/ui/overview/CardManager.kt
@@ -17,24 +17,23 @@ object CardManager {
     /**
      * Card typ constants
      */
-    enum class CardTypes(val id: Int) {
-        CAFETERIA(R.layout.card_cafeteria_menu),
-        TUITION_FEE(R.layout.card_tuition_fees),
-        NEXT_LECTURE(R.layout.card_next_lecture_item),
-        RESTORE(R.layout.card_restore),
-        NO_INTERNET(R.layout.card_no_internet),
-        MVV(R.layout.card_mvv),
-        NEWS(R.layout.card_news_item),
-        NEWS_FILM(R.layout.card_news_film_item),
-        EDUROAM(R.layout.card_eduroam),
-        CHAT(R.layout.card_chat_messages),
-        SUPPORT(R.layout.card_support),
-        LOGIN(R.layout.card_login_prompt),
-        EDUROAM_FIX(R.layout.card_eduroam_fix),
-        TOP_NEWS(R.layout.card_top_news),
-        EVENT(R.layout.card_events_item),
-        UPDATE_NOTE(R.layout.card_update_note)
-
+    enum class CardTypes(val id: Int, val showCardPreferenceStringRes: Int) {
+        CAFETERIA(R.layout.card_cafeteria_menu, R.string.cafeteria_default_sharedpref_shown),
+        TUITION_FEE(R.layout.card_tuition_fees, R.string.tuition_fee_default_sharedpref_shown),
+        NEXT_LECTURE(R.layout.card_next_lecture_item, R.string.next_lecture_default_sharedpref_shown),
+        RESTORE(R.layout.card_restore, R.string.restore_default_sharedpref_shown),
+        NO_INTERNET(R.layout.card_no_internet, R.string.no_internet_default_sharedpref_shown),
+        MVV(R.layout.card_mvv, R.string.mvv_default_sharedpref_shown),
+        NEWS(R.layout.card_news_item, R.string.news_default_sharedpref_shown),
+        NEWS_FILM(R.layout.card_news_film_item, R.string.news_film_default_sharedpref_shown),
+        EDUROAM(R.layout.card_eduroam, R.string.eduroam_default_sharedpref_shown),
+        CHAT(R.layout.card_chat_messages, R.string.chat_default_sharedpref_shown),
+        SUPPORT(R.layout.card_support, R.string.support_default_sharedpref_shown),
+        LOGIN(R.layout.card_login_prompt, R.string.login_default_sharedpref_shown),
+        EDUROAM_FIX(R.layout.card_eduroam_fix, R.string.eduroam_fix_default_sharedpref_shown),
+        TOP_NEWS(R.layout.card_top_news, R.string.top_news_default_sharedpref_shown),
+        EVENT(R.layout.card_events_item, R.string.event_default_sharedpref_shown),
+        UPDATE_NOTE(R.layout.card_update_note, R.string.update_note_default_sharedpref_shown)
     }
 
     /**

--- a/app/src/main/java/de/tum/in/tumcampusapp/component/ui/overview/CardManager.kt
+++ b/app/src/main/java/de/tum/in/tumcampusapp/component/ui/overview/CardManager.kt
@@ -5,16 +5,13 @@ import android.preference.PreferenceManager
 import de.tum.`in`.tumcampusapp.R
 import de.tum.`in`.tumcampusapp.database.TcaDb
 import de.tum.`in`.tumcampusapp.utils.Const.CARD_POSITION_PREFERENCE_SUFFIX
-import de.tum.`in`.tumcampusapp.utils.Const.DISCARD_SETTINGS_START
 import de.tum.`in`.tumcampusapp.utils.Utils
-import org.jetbrains.anko.defaultSharedPreferences
 
 /**
  * Card manager, manages inserting, dismissing, updating and displaying of cards
  */
 object CardManager {
 
-    const val SHOW_SUPPORT = "show_support"
     const val SHOW_TOP_NEWS = "show_top_news"
 
     /**
@@ -40,42 +37,16 @@ object CardManager {
 
     }
 
-    const val CARD_CAFETERIA = R.layout.card_cafeteria_menu
-    const val CARD_TUITION_FEE = R.layout.card_tuition_fees
-    const val CARD_NEXT_LECTURE = R.layout.card_next_lecture_item
-    const val CARD_RESTORE = R.layout.card_restore
-    const val CARD_NO_INTERNET = R.layout.card_no_internet
-    const val CARD_MVV = R.layout.card_mvv
-    const val CARD_NEWS = R.layout.card_news_item
-    const val CARD_NEWS_FILM = R.layout.card_news_film_item
-    const val CARD_EDUROAM = R.layout.card_eduroam
-    const val CARD_CHAT = R.layout.card_chat_messages
-    const val CARD_SUPPORT = R.layout.card_support
-    const val CARD_LOGIN = R.layout.card_login_prompt
-    const val CARD_EDUROAM_FIX = R.layout.card_eduroam_fix
-    const val CARD_TOP_NEWS = R.layout.card_top_news
-    const val CARD_EVENT = R.layout.card_events_item
-    const val CARD_UPDATE_NOTE = R.layout.card_update_note
-
     /**
      * Resets dismiss settings for all cards
      */
     fun restoreCards(context: Context) {
         CardTypes.values().forEach {
-            context.getSharedPreferences("CardPref" + it.id.toString(), Context.MODE_PRIVATE)
+            context.getSharedPreferences("CardPref$it", Context.MODE_PRIVATE)
                 .edit()
-                // wipe completly
                 .clear()
-                //.putBoolean("shouldShow", true)
                 .apply()
         }
-
-        println("HierHier" + "restored")
-
-        context.getSharedPreferences(DISCARD_SETTINGS_START, 0)
-            .edit()
-            .clear()
-            .apply()
 
         TcaDb.getInstance(context)
             .newsDao()

--- a/app/src/main/java/de/tum/in/tumcampusapp/component/ui/overview/CardsRepository.kt
+++ b/app/src/main/java/de/tum/in/tumcampusapp/component/ui/overview/CardsRepository.kt
@@ -23,7 +23,6 @@ import de.tum.`in`.tumcampusapp.utils.Utils
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
-import org.jetbrains.anko.doAsync
 import javax.inject.Inject
 
 class CardsRepository @Inject constructor(
@@ -42,7 +41,6 @@ class CardsRepository @Inject constructor(
      * @return The [LiveData] of [Card]s
      */
     fun getCards(): LiveData<List<Card>> {
-        //refreshCards(CacheControl.USE_CACHE)
         return cards
     }
 

--- a/app/src/main/java/de/tum/in/tumcampusapp/component/ui/overview/CardsRepository.kt
+++ b/app/src/main/java/de/tum/in/tumcampusapp/component/ui/overview/CardsRepository.kt
@@ -20,6 +20,9 @@ import de.tum.`in`.tumcampusapp.component.ui.ticket.EventCardsProvider
 import de.tum.`in`.tumcampusapp.component.ui.transportation.TransportController
 import de.tum.`in`.tumcampusapp.component.ui.updatenote.UpdateNoteCard
 import de.tum.`in`.tumcampusapp.utils.Utils
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 import org.jetbrains.anko.doAsync
 import javax.inject.Inject
 
@@ -30,6 +33,8 @@ class CardsRepository @Inject constructor(
 
     private var cards = MutableLiveData<List<Card>>()
 
+    private val ioDispatcher: CoroutineDispatcher = Dispatchers.IO
+
     /**
      * Starts refresh of [Card]s and returns the corresponding [LiveData]
      * through which the result can be received.
@@ -37,15 +42,15 @@ class CardsRepository @Inject constructor(
      * @return The [LiveData] of [Card]s
      */
     fun getCards(): LiveData<List<Card>> {
-        refreshCards(CacheControl.USE_CACHE)
+        //refreshCards(CacheControl.USE_CACHE)
         return cards
     }
 
     /**
      * Refreshes the [LiveData] of [Card]s and updates its value.
      */
-    fun refreshCards(cacheControl: CacheControl) {
-        doAsync {
+    suspend fun refreshCards(cacheControl: CacheControl) {
+        withContext(ioDispatcher) {
             val results = getCardsNow(cacheControl)
             cards.postValue(results)
         }

--- a/app/src/main/java/de/tum/in/tumcampusapp/component/ui/overview/MainActivityViewModel.kt
+++ b/app/src/main/java/de/tum/in/tumcampusapp/component/ui/overview/MainActivityViewModel.kt
@@ -2,8 +2,10 @@ package de.tum.`in`.tumcampusapp.component.ui.overview
 
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
 import de.tum.`in`.tumcampusapp.api.tumonline.CacheControl
 import de.tum.`in`.tumcampusapp.component.ui.overview.card.Card
+import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 class MainActivityViewModel @Inject constructor(
@@ -11,9 +13,16 @@ class MainActivityViewModel @Inject constructor(
 ) : ViewModel() {
 
     val cards: LiveData<List<Card>>
-        get() = cardsRepo.getCards()
+        get() {
+            viewModelScope.launch {
+                cardsRepo.refreshCards(CacheControl.USE_CACHE)
+            }
+            return cardsRepo.getCards()
+        }
 
     fun refreshCards() {
-        cardsRepo.refreshCards(CacheControl.BYPASS_CACHE)
+        viewModelScope.launch {
+            cardsRepo.refreshCards(CacheControl.BYPASS_CACHE)
+        }
     }
 }

--- a/app/src/main/java/de/tum/in/tumcampusapp/component/ui/overview/MainFragment.kt
+++ b/app/src/main/java/de/tum/in/tumcampusapp/component/ui/overview/MainFragment.kt
@@ -126,7 +126,6 @@ class MainFragment : BaseFragment<Unit>(
         swipeRefreshLayout.isRefreshing = true
         onRefresh()
         downloadNewsAlert()
-        println("Refresh finished")
     }
 
     private fun onNewCardsAvailable(cards: List<Card>) {

--- a/app/src/main/java/de/tum/in/tumcampusapp/component/ui/overview/MainFragment.kt
+++ b/app/src/main/java/de/tum/in/tumcampusapp/component/ui/overview/MainFragment.kt
@@ -126,6 +126,7 @@ class MainFragment : BaseFragment<Unit>(
         swipeRefreshLayout.isRefreshing = true
         onRefresh()
         downloadNewsAlert()
+        println("Refresh finished")
     }
 
     private fun onNewCardsAvailable(cards: List<Card>) {

--- a/app/src/main/java/de/tum/in/tumcampusapp/component/ui/overview/MainFragment.kt
+++ b/app/src/main/java/de/tum/in/tumcampusapp/component/ui/overview/MainFragment.kt
@@ -154,10 +154,9 @@ class MainFragment : BaseFragment<Unit>(
         // if shown also refreshCards is called inside the dismiss-callback of the SnackBar
         // this guarantees that it is always called after the dismissal is completed
         // which because of the callback would not be the case otherwise
-        if(snackBar != null && snackBar!!.isShown){
+        if (snackBar != null && snackBar!!.isShown) {
             snackBar!!.dismiss()
-        }
-        else{
+        } else {
             viewModel.refreshCards()
         }
     }
@@ -256,7 +255,7 @@ class MainFragment : BaseFragment<Unit>(
                                     // and therefore, we didn't really dismiss the card
                                     card?.discard()
                                 }
-                                if(event == DISMISS_EVENT_MANUAL){
+                                if (event == DISMISS_EVENT_MANUAL) {
                                     // manual dismissal means we need to call refresh here
                                     viewModel.refreshCards()
                                 }

--- a/app/src/main/java/de/tum/in/tumcampusapp/component/ui/overview/NoInternetCard.kt
+++ b/app/src/main/java/de/tum/in/tumcampusapp/component/ui/overview/NoInternetCard.kt
@@ -17,7 +17,7 @@ import org.joda.time.DateTime
 /**
  * Card that informs that no internet connection is available
  */
-class NoInternetCard(context: Context) : StickyCard(CardManager.CARD_NO_INTERNET, context) {
+class NoInternetCard(context: Context) : StickyCard(CardManager.CardTypes.NO_INTERNET, context) {
 
     override fun updateViewHolder(viewHolder: RecyclerView.ViewHolder) {
         super.updateViewHolder(viewHolder)

--- a/app/src/main/java/de/tum/in/tumcampusapp/component/ui/overview/RestoreCard.kt
+++ b/app/src/main/java/de/tum/in/tumcampusapp/component/ui/overview/RestoreCard.kt
@@ -12,7 +12,7 @@ import de.tum.`in`.tumcampusapp.component.ui.overview.card.StickyCard
 /**
  * Card that allows the user to reset the dismiss state of all cards
  */
-class RestoreCard(context: Context) : StickyCard(CardManager.CARD_RESTORE, context) {
+class RestoreCard(context: Context) : StickyCard(CardManager.CardTypes.RESTORE, context) {
 
     /**
      * Override getPositionByDate, we want the RestoreCard to be the last card.

--- a/app/src/main/java/de/tum/in/tumcampusapp/component/ui/overview/SupportCard.kt
+++ b/app/src/main/java/de/tum/in/tumcampusapp/component/ui/overview/SupportCard.kt
@@ -12,19 +12,21 @@ import android.view.ViewGroup
 import de.tum.`in`.tumcampusapp.R
 import de.tum.`in`.tumcampusapp.component.ui.overview.card.Card
 import de.tum.`in`.tumcampusapp.component.ui.overview.card.CardViewHolder
-import de.tum.`in`.tumcampusapp.utils.Utils
 
 /**
  * Card that describes how to dismiss a card
  */
-class SupportCard(context: Context) : Card(CardManager.CARD_SUPPORT, context, "") {
+class SupportCard(context: Context) : Card(CardManager.CardTypes.SUPPORT, context, "") {
+
+    private val SHOW_SUPPORT = "show_support"
 
     public override fun discard(editor: Editor) {
-        Utils.setSetting(context, CardManager.SHOW_SUPPORT, false)
+        editor.putBoolean(SHOW_SUPPORT, false)
     }
 
-    override fun shouldShow(prefs: SharedPreferences) =
-            Utils.getSettingBool(context, CardManager.SHOW_SUPPORT, true)
+    override fun shouldShow(prefs: SharedPreferences): Boolean {
+        return prefs.getBoolean(SHOW_SUPPORT, true)
+    }
 
     override fun getId() = 0
 
@@ -34,14 +36,18 @@ class SupportCard(context: Context) : Card(CardManager.CARD_SUPPORT, context, ""
             val view = LayoutInflater.from(parent.context).inflate(R.layout.card_support, parent, false)
             view.findViewById<View>(R.id.facebook_button).setOnClickListener { v ->
                 val browserIntent = Intent(Intent.ACTION_VIEW)
-                browserIntent.data = Uri.parse(view.context
-                        .getString(R.string.facebook_link))
+                browserIntent.data = Uri.parse(
+                    view.context
+                        .getString(R.string.facebook_link)
+                )
                 v.context.startActivity(browserIntent)
             }
             view.findViewById<View>(R.id.github_button).setOnClickListener { v ->
                 val browserIntent = Intent(Intent.ACTION_VIEW)
-                browserIntent.data = Uri.parse(view.context
-                        .getString(R.string.github_link))
+                browserIntent.data = Uri.parse(
+                    view.context
+                        .getString(R.string.github_link)
+                )
                 v.context.startActivity(browserIntent)
             }
             view.findViewById<View>(R.id.email_button).setOnClickListener { v ->

--- a/app/src/main/java/de/tum/in/tumcampusapp/component/ui/overview/SupportCard.kt
+++ b/app/src/main/java/de/tum/in/tumcampusapp/component/ui/overview/SupportCard.kt
@@ -16,16 +16,16 @@ import de.tum.`in`.tumcampusapp.component.ui.overview.card.CardViewHolder
 /**
  * Card that describes how to dismiss a card
  */
-class SupportCard(context: Context) : Card(CardManager.CardTypes.SUPPORT, context, "") {
+class SupportCard(context: Context) : Card(CardManager.CardTypes.SUPPORT, context) {
 
-    private val SHOW_SUPPORT = "show_support"
+    private val showSupport = "show_support"
 
     public override fun discard(editor: Editor) {
-        editor.putBoolean(SHOW_SUPPORT, false)
+        editor.putBoolean(showSupport, false)
     }
 
     override fun shouldShow(prefs: SharedPreferences): Boolean {
-        return prefs.getBoolean(SHOW_SUPPORT, true)
+        return prefs.getBoolean(showSupport, true)
     }
 
     override fun getId() = 0

--- a/app/src/main/java/de/tum/in/tumcampusapp/component/ui/overview/card/Card.kt
+++ b/app/src/main/java/de/tum/in/tumcampusapp/component/ui/overview/card/Card.kt
@@ -108,7 +108,6 @@ abstract class Card(
             .putBoolean(context.getString(cardType.showCardPreferenceStringRes), false)
             .apply()
         Utils.log("Hiding card: $cardType")
-        println()
     }
 
     override fun compareTo(other: Card): Int {

--- a/app/src/main/java/de/tum/in/tumcampusapp/component/ui/overview/card/Card.kt
+++ b/app/src/main/java/de/tum/in/tumcampusapp/component/ui/overview/card/Card.kt
@@ -10,6 +10,7 @@ import de.tum.`in`.tumcampusapp.component.other.navigation.NavDestination
 import de.tum.`in`.tumcampusapp.utils.Const.CARD_POSITION_PREFERENCE_SUFFIX
 import de.tum.`in`.tumcampusapp.utils.Const.DISCARD_SETTINGS_START
 import de.tum.`in`.tumcampusapp.utils.Utils
+import org.jetbrains.anko.defaultSharedPreferences
 
 /**
  * Base class for all cards
@@ -24,7 +25,9 @@ abstract class Card(
 ) : Comparable<Card> {
 
     // Settings for showing this card on start page or as notification
-    private var showStart = Utils.getSettingBool(context, settingsPrefix + "_start", true)
+    //private var showStart = Utils.getSettingBool(context, settingsPrefix + "_start", true)
+    private val cardSharedPreferences = context.getSharedPreferences("CardPref$cardType", Context.MODE_PRIVATE)
+    private val shouldShowPrefName = "shouldShow"
 
     open fun getId(): Int {
         return 0
@@ -70,8 +73,8 @@ abstract class Card(
      * Should be called after the user has dismissed the card
      */
     fun discard() {
-        val prefs = context.getSharedPreferences(DISCARD_SETTINGS_START, 0)
-        val editor = prefs.edit()
+        //val prefs = context.getSharedPreferences(DISCARD_SETTINGS_START, 0)
+        val editor = cardSharedPreferences.edit()
         discard(editor)
         editor.apply()
     }
@@ -82,17 +85,20 @@ abstract class Card(
      * @return The Card to be displayed or null
      */
     open fun getIfShowOnStart(): Card? {
-        if (showStart) {
-            val prefs = context.getSharedPreferences(DISCARD_SETTINGS_START, 0)
-            if (shouldShow(prefs)) {
+        println("ShownOnStart " + context.resources.getResourceEntryName(cardType) + cardSharedPreferences.getBoolean("shouldShow", true))
+        if (cardSharedPreferences.getBoolean(shouldShowPrefName, true)) {
+            //val prefs = context.getSharedPreferences(DISCARD_SETTINGS_START, 0)
+            if (shouldShow(cardSharedPreferences)) {
                 return this
             }
+            println("ShownOnStart2 " + context.resources.getResourceEntryName(cardType) +  shouldShow(cardSharedPreferences))
+
         }
         return null
     }
 
     /**
-     * Determines if the card should be shown. Decision is based on the given SharedPreferences.
+     * Determines if the card should be shown at the card level. Decision is based on the given SharedPreferences.
      * This method should be overridden in most cases.
      *
      * @return returns true if the card should be shown
@@ -106,12 +112,17 @@ abstract class Card(
      * reactivated manually by the user
      */
     open fun hideAlways() {
-        val prefs = PreferenceManager.getDefaultSharedPreferences(context)
+        cardSharedPreferences
+            .edit()
+            .putBoolean(shouldShowPrefName, false)
+            .apply()
+        Utils.log("Hiding card: $cardType")
+        /*val prefs = PreferenceManager.getDefaultSharedPreferences(context)
         val e = prefs.edit()
         e.putBoolean(settingsPrefix + "_start", false)
         e.putBoolean(settingsPrefix + "_phone", false)
         e.apply()
-        Utils.log("Hiding card: $settingsPrefix")
+        Utils.log("Hiding card: $settingsPrefix")*/
     }
 
     override fun compareTo(other: Card): Int {

--- a/app/src/main/java/de/tum/in/tumcampusapp/component/ui/overview/card/Card.kt
+++ b/app/src/main/java/de/tum/in/tumcampusapp/component/ui/overview/card/Card.kt
@@ -18,7 +18,7 @@ import org.jetbrains.anko.defaultSharedPreferences
  */
 abstract class Card(
     val cardType: CardManager.CardTypes,
-    protected var context: Context,
+    protected var context: Context
 ) : Comparable<Card> {
 
     // stores information for dismiss
@@ -131,9 +131,9 @@ abstract class Card(
         override fun getNewListSize() = newList.size
 
         override fun areItemsTheSame(oldItemPosition: Int, newItemPosition: Int) =
-                oldList[oldItemPosition].cardType == newList[newItemPosition].cardType
+            oldList[oldItemPosition].cardType == newList[newItemPosition].cardType
 
         override fun areContentsTheSame(oldItemPosition: Int, newItemPosition: Int) =
-                oldList[oldItemPosition] == newList[newItemPosition]
+            oldList[oldItemPosition] == newList[newItemPosition]
     }
 }

--- a/app/src/main/java/de/tum/in/tumcampusapp/component/ui/overview/card/Card.kt
+++ b/app/src/main/java/de/tum/in/tumcampusapp/component/ui/overview/card/Card.kt
@@ -68,7 +68,6 @@ abstract class Card(
      * Should be called after the user has dismissed the card
      */
     fun discard() {
-        //val prefs = context.getSharedPreferences(DISCARD_SETTINGS_START, 0)
         val editor = dismissCardSharedPreferences.edit()
         discard(editor)
         editor.apply()

--- a/app/src/main/java/de/tum/in/tumcampusapp/component/ui/overview/card/Card.kt
+++ b/app/src/main/java/de/tum/in/tumcampusapp/component/ui/overview/card/Card.kt
@@ -3,12 +3,11 @@ package de.tum.`in`.tumcampusapp.component.ui.overview.card
 import android.content.Context
 import android.content.SharedPreferences
 import android.content.SharedPreferences.Editor
-import android.preference.PreferenceManager
 import androidx.recyclerview.widget.DiffUtil
 import de.tum.`in`.tumcampusapp.R
 import de.tum.`in`.tumcampusapp.component.other.navigation.NavDestination
+import de.tum.`in`.tumcampusapp.component.ui.overview.CardManager
 import de.tum.`in`.tumcampusapp.utils.Const.CARD_POSITION_PREFERENCE_SUFFIX
-import de.tum.`in`.tumcampusapp.utils.Const.DISCARD_SETTINGS_START
 import de.tum.`in`.tumcampusapp.utils.Utils
 import org.jetbrains.anko.defaultSharedPreferences
 
@@ -19,14 +18,14 @@ import org.jetbrains.anko.defaultSharedPreferences
  * @param settingsPrefix Preference key prefix used for all preferences belonging to that card
  */
 abstract class Card(
-    val cardType: Int,
+    val cardType: CardManager.CardTypes,
     protected var context: Context,
     val settingsPrefix: String = ""
 ) : Comparable<Card> {
 
     // Settings for showing this card on start page or as notification
     //private var showStart = Utils.getSettingBool(context, settingsPrefix + "_start", true)
-    private val cardSharedPreferences = context.getSharedPreferences("CardPref$cardType", Context.MODE_PRIVATE)
+    private val cardSharedPreferences: SharedPreferences = context.getSharedPreferences("CardPref$cardType", Context.MODE_PRIVATE)
     private val shouldShowPrefName = "shouldShow"
 
     open fun getId(): Int {
@@ -85,14 +84,10 @@ abstract class Card(
      * @return The Card to be displayed or null
      */
     open fun getIfShowOnStart(): Card? {
-        println("ShownOnStart " + context.resources.getResourceEntryName(cardType) + cardSharedPreferences.getBoolean("shouldShow", true))
-        if (cardSharedPreferences.getBoolean(shouldShowPrefName, true)) {
-            //val prefs = context.getSharedPreferences(DISCARD_SETTINGS_START, 0)
+        if (context.defaultSharedPreferences.getBoolean("$cardType$shouldShowPrefName", true)) {
             if (shouldShow(cardSharedPreferences)) {
                 return this
             }
-            println("ShownOnStart2 " + context.resources.getResourceEntryName(cardType) +  shouldShow(cardSharedPreferences))
-
         }
         return null
     }
@@ -112,17 +107,11 @@ abstract class Card(
      * reactivated manually by the user
      */
     open fun hideAlways() {
-        cardSharedPreferences
+        context.defaultSharedPreferences
             .edit()
-            .putBoolean(shouldShowPrefName, false)
+            .putBoolean("$cardType$shouldShowPrefName", false)
             .apply()
         Utils.log("Hiding card: $cardType")
-        /*val prefs = PreferenceManager.getDefaultSharedPreferences(context)
-        val e = prefs.edit()
-        e.putBoolean(settingsPrefix + "_start", false)
-        e.putBoolean(settingsPrefix + "_phone", false)
-        e.apply()
-        Utils.log("Hiding card: $settingsPrefix")*/
     }
 
     override fun compareTo(other: Card): Int {

--- a/app/src/main/java/de/tum/in/tumcampusapp/component/ui/overview/card/Card.kt
+++ b/app/src/main/java/de/tum/in/tumcampusapp/component/ui/overview/card/Card.kt
@@ -114,7 +114,8 @@ abstract class Card(
     }
 
     /**
-     * Save information about the dismissed card/notification to decide later if the cardView should be shown again
+     * Save information about the dismissed card/notification to decide later if the cardView should be shown again.
+     * It is exclusively called from [discard] where the changes made to the SharedPreferences are applied.
      *
      * @param editor Editor to be used for saving values
      */

--- a/app/src/main/java/de/tum/in/tumcampusapp/component/ui/overview/card/Card.kt
+++ b/app/src/main/java/de/tum/in/tumcampusapp/component/ui/overview/card/Card.kt
@@ -15,12 +15,10 @@ import org.jetbrains.anko.defaultSharedPreferences
  * Base class for all cards
  * @param cardType Individual integer for each card type
  * @param context Android Context
- * @param settingsPrefix Preference key prefix used for all preferences belonging to that card
  */
 abstract class Card(
     val cardType: CardManager.CardTypes,
     protected var context: Context,
-    val settingsPrefix: String = ""
 ) : Comparable<Card> {
 
     // stores information for dismiss

--- a/app/src/main/java/de/tum/in/tumcampusapp/component/ui/overview/card/Card.kt
+++ b/app/src/main/java/de/tum/in/tumcampusapp/component/ui/overview/card/Card.kt
@@ -23,10 +23,8 @@ abstract class Card(
     val settingsPrefix: String = ""
 ) : Comparable<Card> {
 
-    // Settings for showing this card on start page or as notification
-    //private var showStart = Utils.getSettingBool(context, settingsPrefix + "_start", true)
-    private val cardSharedPreferences: SharedPreferences = context.getSharedPreferences("CardPref$cardType", Context.MODE_PRIVATE)
-    private val shouldShowPrefName = "shouldShow"
+    // stores information for dismiss
+    private val dismissCardSharedPreferences: SharedPreferences = context.getSharedPreferences("CardPref$cardType", Context.MODE_PRIVATE)
 
     open fun getId(): Int {
         return 0
@@ -73,7 +71,7 @@ abstract class Card(
      */
     fun discard() {
         //val prefs = context.getSharedPreferences(DISCARD_SETTINGS_START, 0)
-        val editor = cardSharedPreferences.edit()
+        val editor = dismissCardSharedPreferences.edit()
         discard(editor)
         editor.apply()
     }
@@ -84,8 +82,8 @@ abstract class Card(
      * @return The Card to be displayed or null
      */
     open fun getIfShowOnStart(): Card? {
-        if (context.defaultSharedPreferences.getBoolean("$cardType$shouldShowPrefName", true)) {
-            if (shouldShow(cardSharedPreferences)) {
+        if (context.defaultSharedPreferences.getBoolean(context.getString(cardType.showCardPreferenceStringRes), true)) {
+            if (shouldShow(dismissCardSharedPreferences)) {
                 return this
             }
         }
@@ -109,9 +107,10 @@ abstract class Card(
     open fun hideAlways() {
         context.defaultSharedPreferences
             .edit()
-            .putBoolean("$cardType$shouldShowPrefName", false)
+            .putBoolean(context.getString(cardType.showCardPreferenceStringRes), false)
             .apply()
         Utils.log("Hiding card: $cardType")
+        println()
     }
 
     override fun compareTo(other: Card): Int {

--- a/app/src/main/java/de/tum/in/tumcampusapp/component/ui/overview/card/CardViewHolder.kt
+++ b/app/src/main/java/de/tum/in/tumcampusapp/component/ui/overview/card/CardViewHolder.kt
@@ -54,7 +54,8 @@ open class CardViewHolder @JvmOverloads constructor(
     }
 
     private fun openCardSettings() {
-        val key = currentCard?.settingsPrefix ?: return
+        val resId = currentCard?.cardType?.showCardPreferenceStringRes ?: return
+        val key = context.getString(resId)
         val intent = SettingsActivity.newIntent(context, key)
         context.startActivity(intent)
     }

--- a/app/src/main/java/de/tum/in/tumcampusapp/component/ui/overview/card/StickyCard.kt
+++ b/app/src/main/java/de/tum/in/tumcampusapp/component/ui/overview/card/StickyCard.kt
@@ -2,8 +2,9 @@ package de.tum.`in`.tumcampusapp.component.ui.overview.card
 
 import android.content.Context
 import android.content.SharedPreferences
+import de.tum.`in`.tumcampusapp.component.ui.overview.CardManager
 
-abstract class StickyCard(cardType: Int, context: Context) : Card(cardType, context) {
+abstract class StickyCard(cardType: CardManager.CardTypes, context: Context) : Card(cardType, context) {
 
     override val isDismissible: Boolean
         get() = false

--- a/app/src/main/java/de/tum/in/tumcampusapp/component/ui/ticket/EventCard.kt
+++ b/app/src/main/java/de/tum/in/tumcampusapp/component/ui/ticket/EventCard.kt
@@ -21,7 +21,7 @@ import de.tum.`in`.tumcampusapp.component.ui.tufilm.KinoActivity
 import de.tum.`in`.tumcampusapp.database.TcaDb
 import de.tum.`in`.tumcampusapp.utils.Const
 
-class EventCard(context: Context) : Card(CardManager.CardTypes.EVENT, context, "card_event") {
+class EventCard(context: Context) : Card(CardManager.CardTypes.EVENT, context) {
 
     var event: Event? = null
 

--- a/app/src/main/java/de/tum/in/tumcampusapp/component/ui/ticket/EventCard.kt
+++ b/app/src/main/java/de/tum/in/tumcampusapp/component/ui/ticket/EventCard.kt
@@ -21,7 +21,7 @@ import de.tum.`in`.tumcampusapp.component.ui.tufilm.KinoActivity
 import de.tum.`in`.tumcampusapp.database.TcaDb
 import de.tum.`in`.tumcampusapp.utils.Const
 
-class EventCard(context: Context) : Card(CardManager.CARD_EVENT, context, "card_event") {
+class EventCard(context: Context) : Card(CardManager.CardTypes.EVENT, context, "card_event") {
 
     var event: Event? = null
 

--- a/app/src/main/java/de/tum/in/tumcampusapp/component/ui/transportation/MVVCard.kt
+++ b/app/src/main/java/de/tum/in/tumcampusapp/component/ui/transportation/MVVCard.kt
@@ -19,7 +19,7 @@ import de.tum.`in`.tumcampusapp.component.ui.transportation.model.efa.StationRes
 /**
  * Card that shows MVV departure times
  */
-class MVVCard(context: Context, val station: StationResult, val departures: List<Departure>) : Card(CardManager.CardTypes.MVV, context, "card_mvv") {
+class MVVCard(context: Context, val station: StationResult, val departures: List<Departure>) : Card(CardManager.CardTypes.MVV, context) {
 
     override val optionsMenuResId: Int
         get() = R.menu.card_popup_menu

--- a/app/src/main/java/de/tum/in/tumcampusapp/component/ui/transportation/MVVCard.kt
+++ b/app/src/main/java/de/tum/in/tumcampusapp/component/ui/transportation/MVVCard.kt
@@ -10,7 +10,7 @@ import androidx.recyclerview.widget.RecyclerView
 import de.tum.`in`.tumcampusapp.R
 import de.tum.`in`.tumcampusapp.component.other.navigation.NavDestination
 import de.tum.`in`.tumcampusapp.component.ui.overview.CardInteractionListener
-import de.tum.`in`.tumcampusapp.component.ui.overview.CardManager.CARD_MVV
+import de.tum.`in`.tumcampusapp.component.ui.overview.CardManager
 import de.tum.`in`.tumcampusapp.component.ui.overview.card.Card
 import de.tum.`in`.tumcampusapp.component.ui.overview.card.CardViewHolder
 import de.tum.`in`.tumcampusapp.component.ui.transportation.model.efa.Departure
@@ -19,7 +19,7 @@ import de.tum.`in`.tumcampusapp.component.ui.transportation.model.efa.StationRes
 /**
  * Card that shows MVV departure times
  */
-class MVVCard(context: Context, val station: StationResult, val departures: List<Departure>) : Card(CARD_MVV, context, "card_mvv") {
+class MVVCard(context: Context, val station: StationResult, val departures: List<Departure>) : Card(CardManager.CardTypes.MVV, context, "card_mvv") {
 
     override val optionsMenuResId: Int
         get() = R.menu.card_popup_menu

--- a/app/src/main/java/de/tum/in/tumcampusapp/component/ui/tufilm/FilmCard.kt
+++ b/app/src/main/java/de/tum/in/tumcampusapp/component/ui/tufilm/FilmCard.kt
@@ -13,7 +13,7 @@ import de.tum.`in`.tumcampusapp.utils.DateTimeUtils
 class FilmCard(
     context: Context,
     news: News
-) : NewsCard(context, news, CardManager.CARD_NEWS_FILM) {
+) : NewsCard(context, news, CardManager.CardTypes.NEWS_FILM) {
     override fun getNavigationDestination(): NavDestination {
         val args = Bundle()
         args.putString(Const.KINO_DATE, DateTimeUtils.getDateTimeString(date))

--- a/app/src/main/java/de/tum/in/tumcampusapp/component/ui/updatenote/UpdateNoteCard.kt
+++ b/app/src/main/java/de/tum/in/tumcampusapp/component/ui/updatenote/UpdateNoteCard.kt
@@ -16,7 +16,7 @@ import de.tum.`in`.tumcampusapp.component.ui.overview.card.CardViewHolder
 import de.tum.`in`.tumcampusapp.utils.Const
 import de.tum.`in`.tumcampusapp.utils.Utils
 
-class UpdateNoteCard(context: Context) : Card(CardManager.CardTypes.UPDATE_NOTE, context, "update_note") {
+class UpdateNoteCard(context: Context) : Card(CardManager.CardTypes.UPDATE_NOTE, context) {
 
     override fun updateViewHolder(viewHolder: RecyclerView.ViewHolder) {
         super.updateViewHolder(viewHolder)

--- a/app/src/main/java/de/tum/in/tumcampusapp/component/ui/updatenote/UpdateNoteCard.kt
+++ b/app/src/main/java/de/tum/in/tumcampusapp/component/ui/updatenote/UpdateNoteCard.kt
@@ -16,7 +16,7 @@ import de.tum.`in`.tumcampusapp.component.ui.overview.card.CardViewHolder
 import de.tum.`in`.tumcampusapp.utils.Const
 import de.tum.`in`.tumcampusapp.utils.Utils
 
-class UpdateNoteCard(context: Context) : Card(CardManager.CARD_UPDATE_NOTE, context, "update_note") {
+class UpdateNoteCard(context: Context) : Card(CardManager.CardTypes.UPDATE_NOTE, context, "update_note") {
 
     override fun updateViewHolder(viewHolder: RecyclerView.ViewHolder) {
         super.updateViewHolder(viewHolder)
@@ -26,12 +26,12 @@ class UpdateNoteCard(context: Context) : Card(CardManager.CARD_UPDATE_NOTE, cont
     }
 
     override fun shouldShow(prefs: SharedPreferences): Boolean {
-        return Utils.getSettingBool(context, Const.SHOW_UPDATE_NOTE, false) &&
+        return prefs.getBoolean(Const.SHOW_UPDATE_NOTE, false) &&
         Utils.getSetting(context, Const.UPDATE_MESSAGE, "").isNotEmpty()
     }
 
     override fun discard(editor: SharedPreferences.Editor) {
-        Utils.setSetting(context, Const.SHOW_UPDATE_NOTE, false)
+        editor.putBoolean(Const.SHOW_UPDATE_NOTE, false)
     }
 
     companion object {

--- a/app/src/main/res/drawable/ic_celebration.xml
+++ b/app/src/main/res/drawable/ic_celebration.xml
@@ -1,0 +1,21 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportHeight="24.0"
+    android:viewportWidth="24.0">
+    <path
+        android:fillColor="@color/text_primary"
+        android:pathData="M2,22l14,-5L7,8L2,22zM12.35,16.18L5.3,18.7l2.52,-7.05L12.35,16.18z" />
+    <path
+        android:fillColor="@color/text_primary"
+        android:pathData="M14.53,12.53l5.59,-5.59c0.49,-0.49 1.28,-0.49 1.77,0l0.59,0.59l1.06,-1.06l-0.59,-0.59c-1.07,-1.07 -2.82,-1.07 -3.89,0l-5.59,5.59L14.53,12.53z" />
+    <path
+        android:fillColor="@color/text_primary"
+        android:pathData="M10.06,6.88L9.47,7.47l1.06,1.06l0.59,-0.59c1.07,-1.07 1.07,-2.82 0,-3.89l-0.59,-0.59L9.47,4.53l0.59,0.59C10.54,5.6 10.54,6.4 10.06,6.88z" />
+    <path
+        android:fillColor="@color/text_primary"
+        android:pathData="M17.06,11.88l-1.59,1.59l1.06,1.06l1.59,-1.59c0.49,-0.49 1.28,-0.49 1.77,0l1.61,1.61l1.06,-1.06l-1.61,-1.61C19.87,10.81 18.13,10.81 17.06,11.88z" />
+    <path
+        android:fillColor="@color/text_primary"
+        android:pathData="M15.06,5.88l-3.59,3.59l1.06,1.06l3.59,-3.59c1.07,-1.07 1.07,-2.82 0,-3.89l-1.59,-1.59l-1.06,1.06l1.59,1.59C15.54,4.6 15.54,5.4 15.06,5.88z" />
+</vector>

--- a/app/src/main/res/drawable/ic_download.xml
+++ b/app/src/main/res/drawable/ic_download.xml
@@ -1,0 +1,5 @@
+<vector android:height="24dp" android:tint="#000000"
+    android:viewportHeight="24" android:viewportWidth="24"
+    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="@android:color/white" android:pathData="M19,9h-4L15,3L9,3v6L5,9l7,7 7,-7zM11,11L11,5h2v6h1.17L12,13.17 9.83,11L11,11zM5,18h14v2L5,20z"/>
+</vector>

--- a/app/src/main/res/drawable/ic_live_help.xml
+++ b/app/src/main/res/drawable/ic_live_help.xml
@@ -1,0 +1,5 @@
+<vector android:autoMirrored="true" android:height="24dp"
+    android:tint="#000000" android:viewportHeight="24"
+    android:viewportWidth="24" android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="@android:color/white" android:pathData="M19,2L5,2c-1.11,0 -2,0.9 -2,2v14c0,1.1 0.89,2 2,2h4l3,3 3,-3h4c1.1,0 2,-0.9 2,-2L21,4c0,-1.1 -0.9,-2 -2,-2zM19,18h-4.83l-0.59,0.59L12,20.17l-1.59,-1.59 -0.58,-0.58L5,18L5,4h14v14zM11,15h2v2h-2zM12,7c1.1,0 2,0.9 2,2 0,2 -3,1.75 -3,5h2c0,-2.25 3,-2.5 3,-5 0,-2.21 -1.79,-4 -4,-4S8,6.79 8,9h2c0,-1.1 0.9,-2 2,-2z"/>
+</vector>

--- a/app/src/main/res/drawable/ic_person_24.xml
+++ b/app/src/main/res/drawable/ic_person_24.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportHeight="24.0"
+    android:viewportWidth="24.0">
+    <path
+        android:fillColor="@color/text_primary"
+        android:pathData="M12,6c1.1,0 2,0.9 2,2s-0.9,2 -2,2 -2,-0.9 -2,-2 0.9,-2 2,-2m0,10c2.7,0 5.8,1.29 6,2L6,18c0.23,-0.72 3.31,-2 6,-2m0,-12C9.79,4 8,5.79 8,8s1.79,4 4,4 4,-1.79 4,-4 -1.79,-4 -4,-4zM12,14c-2.67,0 -8,1.34 -8,4v2h16v-2c0,-2.66 -5.33,-4 -8,-4z" />
+</vector>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -353,8 +353,8 @@
 
     <!-- extra startpage show names for news -->
     <string name="startpage_news">Startseite News</string>
-    <string name="startpage_top_news">Startpage Top-News</string>
-    <string name="startpage_film_news">Startpage Film-News</string>
+    <string name="startpage_top_news">Startseite Top-News</string>
+    <string name="startpage_film_news">Startseite Film-News</string>
 
     <string name="opens">Öffnet</string>
     <string name="closes">Schließt</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -340,8 +340,12 @@
     <string name="card_next_lecture_summary">Zeigt Informationen zur nächsten Vorlesung an</string>
     <string name="card_tuition_fee_summary">Erinnert dich, wenn du die Studiengebühren zahlen musst</string>
     <string name="card_support_summary">Unterstütze uns durch Feedback oder teilen der App</string>
+    <string name="card_no_internet_summary">Zeigt an wenn keine Internetverbindung vorhanden ist</string>
+    <string name="card_login_summary">Erlaubt dir dich mit TUMOnline zu verbinden</string>
     <string name="card_news_summary">Schlägt ausgewählte News vor</string>
     <string name="card_chat_summary">Benachrichtigt dich über neue Nachrichten</string>
+    <string name="card_events_summary">Zeigt anstehenden Events an</string>
+    <string name="card_update_summary">Gibt eine Übersicht über neue Features</string>
     <string name="open_card_settings">Karte anpassen</string>
     <string name="always_hide_card">Karte immer ausblenden</string>
     <string name="phone_summary">Um Benachrichtigungen auf dem Telefon zu erhalten muss Wearable aktiviert sein</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -339,6 +339,7 @@
     <string name="card_mvv_summary">Zeigt die Abfahrtszeiten der öffentlich Verkehrmittel an</string>
     <string name="card_next_lecture_summary">Zeigt Informationen zur nächsten Vorlesung an</string>
     <string name="card_tuition_fee_summary">Erinnert dich, wenn du die Studiengebühren zahlen musst</string>
+    <string name="card_support_summary">Unterstütze uns durch Feedback oder teilen der App</string>
     <string name="card_news_summary">Schlägt ausgewählte News vor</string>
     <string name="card_chat_summary">Benachrichtigt dich über neue Nachrichten</string>
     <string name="open_card_settings">Karte anpassen</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -347,6 +347,11 @@
     <string name="phone_summary">Um Benachrichtigungen auf dem Telefon zu erhalten muss Wearable aktiviert sein</string>
     <string name="display">Anzeige</string>
 
+    <!-- extra startpage show names for news -->
+    <string name="startpage_news">Startseite News</string>
+    <string name="startpage_top_news">Startpage Top-News</string>
+    <string name="startpage_film_news">Startpage Film-News</string>
+
     <string name="opens">Öffnet</string>
     <string name="closes">Schließt</string>
     <string name="closed">Geschlossen</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -333,6 +333,24 @@
     <string name="reregister_todo">You have to reregister until %s!</string>
     <string name="undo">Undo</string>
 
+    <!-- Cards identifiers for default SharedPref -->
+    <string name="cafeteria_default_sharedpref_shown" translatable="false">CafeteriaCardShown</string>
+    <string name="tuition_fee_default_sharedpref_shown" translatable="false">TuitionFeeCardShown</string>
+    <string name="next_lecture_default_sharedpref_shown" translatable="false">NextLectureCardShown</string>
+    <string name="restore_default_sharedpref_shown" translatable="false">RestoreCardShown</string>
+    <string name="no_internet_default_sharedpref_shown" translatable="false">NoInternetCardShown</string>
+    <string name="mvv_default_sharedpref_shown" translatable="false">MVVCardShown</string>
+    <string name="news_default_sharedpref_shown" translatable="false">NewsCardShown</string>
+    <string name="news_film_default_sharedpref_shown" translatable="false">NewsFilmCardShown</string>
+    <string name="eduroam_default_sharedpref_shown" translatable="false">EduroamCardShown</string>
+    <string name="chat_default_sharedpref_shown" translatable="false">ChatCardShown</string>
+    <string name="support_default_sharedpref_shown" translatable="false">SupportCardShown</string>
+    <string name="login_default_sharedpref_shown" translatable="false">LoginCardShown</string>
+    <string name="eduroam_fix_default_sharedpref_shown" translatable="false">EduroamFixCardShown</string>
+    <string name="top_news_default_sharedpref_shown" translatable="false">TopNewsCardShown</string>
+    <string name="event_default_sharedpref_shown" translatable="false">EventCardShown</string>
+    <string name="update_note_default_sharedpref_shown" translatable="false">UpdateNoteCardShown</string>
+
     <!-- first use tutorial -->
     <string name="swipe_instruction">Swipe left or right to hide a card.</string>
     <string name="card_settings_instruction">If you want to hide a card permanently or you want to be notified if a new card is available open card-settings by long pressing on a card</string>
@@ -390,6 +408,7 @@
     <string name="card_mvv_summary">Shows you the departure times of public transport</string>
     <string name="card_next_lecture_summary">Shows information about your next lecture</string>
     <string name="card_tuition_fee_summary">Reminds you when you have to pay your fees</string>
+    <string name="card_support_summary">Support us by giving feedback or sharing the app</string>
     <string name="card_news_summary">Advertises selected news</string>
     <string name="card_chat_summary">Notifies you about new messages</string>
     <string name="chat" translatable="false">Chat</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -409,8 +409,12 @@
     <string name="card_next_lecture_summary">Shows information about your next lecture</string>
     <string name="card_tuition_fee_summary">Reminds you when you have to pay your fees</string>
     <string name="card_support_summary">Support us by giving feedback or sharing the app</string>
+    <string name="card_no_internet_summary">Shows when there is no internet connection</string>
+    <string name="card_login_summary">Allows you to connect to TUMOnline</string>
     <string name="card_news_summary">Advertises selected news</string>
     <string name="card_chat_summary">Notifies you about new messages</string>
+    <string name="card_events_summary">Shows upcoming events</string>
+    <string name="card_update_summary">Provides an overview about new features</string>
     <string name="chat" translatable="false">Chat</string>
     <string name="open_card_settings">Open card settings</string>
     <string name="always_hide_card">Always hide card</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -417,6 +417,11 @@
     <string name="phone_summary">To receive notifications on your phone you have to enable Wearable</string>
     <string name="display">Display</string>
 
+    <!-- extra startpage show names for news -->
+    <string name="startpage_news">Startpage news</string>
+    <string name="startpage_top_news">Startpage top-news</string>
+    <string name="startpage_film_news">Startpage film-news</string>
+
     <string name="opens">Opens</string>
     <string name="closes">Closes</string>
     <string name="closed">Closed</string>

--- a/app/src/main/res/xml/settings.xml
+++ b/app/src/main/res/xml/settings.xml
@@ -39,7 +39,7 @@
         <!-- Cafeteria card -->
         <androidx.preference.PreferenceScreen
             android:icon="@drawable/ic_cutlery"
-            android:key="card_cafeteria"
+            android:key="@string/cafeteria_default_sharedpref_shown"
             android:summary="@string/card_cafeteria_summary"
             android:title="@string/cafeteria">
 
@@ -145,7 +145,7 @@
         <!-- MVV card-->
         <androidx.preference.PreferenceScreen
             android:icon="@drawable/ic_outline_train_24px"
-            android:key="card_mvv"
+            android:key="@string/mvv_default_sharedpref_shown"
             android:summary="@string/card_mvv_summary"
             android:title="@string/mvv">
 
@@ -188,7 +188,7 @@
         <!-- Next lecture card -->
         <androidx.preference.PreferenceScreen
             android:icon="@drawable/ic_outline_event_24px"
-            android:key="card_next_lecture"
+            android:key="@string/next_lecture_default_sharedpref_shown"
             android:summary="@string/card_next_lecture_summary"
             android:title="@string/next_lecture">
 
@@ -211,7 +211,7 @@
         <!-- Tuition fee card -->
         <androidx.preference.PreferenceScreen
             android:icon="@drawable/ic_money"
-            android:key="card_tuition_fee"
+            android:key="@string/tuition_fee_default_sharedpref_shown"
             android:summary="@string/card_tuition_fee_summary"
             android:title="@string/tuition_fees">
 
@@ -234,7 +234,7 @@
         <!-- Support card -->
         <androidx.preference.PreferenceScreen
             android:icon="@drawable/ic_live_help"
-            android:key="card support"
+            android:key="@string/support_default_sharedpref_shown"
             android:summary="@string/card_support_summary"
             android:title="@string/support_us_title">
 
@@ -252,7 +252,7 @@
         <!-- News card -->
         <androidx.preference.PreferenceScreen
             android:icon="@drawable/ic_rss"
-            android:key="card_news"
+            android:key="@string/news_default_sharedpref_shown"
             android:summary="@string/card_news_summary"
             android:title="@string/news">
 
@@ -334,7 +334,7 @@
         <!-- Eduroam card -->
         <androidx.preference.PreferenceScreen
             android:icon="@drawable/ic_action_network_wifi"
-            android:key="card_eduroam"
+            android:key="@string/eduroam_default_sharedpref_shown"
             android:summary="@string/card_eduroam_summary"
             android:title="@string/eduroam">
 
@@ -365,7 +365,7 @@
         <!-- NoInternet card -->
         <androidx.preference.PreferenceScreen
             android:icon="@drawable/ic_no_wifi"
-            android:key="card nointernet"
+            android:key="@string/no_internet_default_sharedpref_shown"
             android:summary="@string/card_no_internet_summary"
             android:title="@string/no_internet_connection">
 
@@ -383,7 +383,7 @@
         <!-- Login card -->
         <androidx.preference.PreferenceScreen
             android:icon="@drawable/ic_person_24"
-            android:key="card login"
+            android:key="@string/login_default_sharedpref_shown"
             android:summary="@string/card_login_summary"
             android:title="@string/tumonline_login">
 
@@ -401,7 +401,7 @@
         <!-- Event card -->
         <androidx.preference.PreferenceScreen
             android:icon="@drawable/ic_celebration"
-            android:key="card event"
+            android:key="@string/event_default_sharedpref_shown"
             android:summary="@string/card_events_summary"
             android:title="@string/events">
 
@@ -419,7 +419,7 @@
         <!-- Update card -->
         <androidx.preference.PreferenceScreen
             android:icon="@drawable/ic_download"
-            android:key="card update"
+            android:key="@string/update_note_default_sharedpref_shown"
             android:summary="@string/card_update_summary"
             android:title="@string/update_note_title">
 

--- a/app/src/main/res/xml/settings.xml
+++ b/app/src/main/res/xml/settings.xml
@@ -234,7 +234,7 @@
         <!-- Support card -->
         <androidx.preference.PreferenceScreen
             android:icon="@drawable/ic_live_help"
-            android:key="Not used but needed to make clickable"
+            android:key="card support"
             android:summary="@string/card_support_summary"
             android:title="@string/support_us_title">
 
@@ -361,6 +361,80 @@
             </androidx.preference.PreferenceCategory>
 
         </androidx.preference.PreferenceScreen>
+
+        <!-- NoInternet card -->
+        <androidx.preference.PreferenceScreen
+            android:icon="@drawable/ic_no_wifi"
+            android:key="card nointernet"
+            android:summary="@string/card_no_internet_summary"
+            android:title="@string/no_internet_connection">
+
+            <androidx.preference.PreferenceCategory android:title="@string/display">
+
+                <androidx.preference.CheckBoxPreference
+                    android:defaultValue="true"
+                    android:key="@string/no_internet_default_sharedpref_shown"
+                    android:title="@string/startpage" />
+
+            </androidx.preference.PreferenceCategory>
+
+        </androidx.preference.PreferenceScreen>
+
+        <!-- Login card -->
+        <androidx.preference.PreferenceScreen
+            android:icon="@drawable/ic_person_24"
+            android:key="card login"
+            android:summary="@string/card_login_summary"
+            android:title="@string/tumonline_login">
+
+            <androidx.preference.PreferenceCategory android:title="@string/display">
+
+                <androidx.preference.CheckBoxPreference
+                    android:defaultValue="true"
+                    android:key="@string/login_default_sharedpref_shown"
+                    android:title="@string/startpage" />
+
+            </androidx.preference.PreferenceCategory>
+
+        </androidx.preference.PreferenceScreen>
+
+        <!-- Event card -->
+        <androidx.preference.PreferenceScreen
+            android:icon="@drawable/ic_celebration"
+            android:key="card event"
+            android:summary="@string/card_events_summary"
+            android:title="@string/events">
+
+            <androidx.preference.PreferenceCategory android:title="@string/display">
+
+                <androidx.preference.CheckBoxPreference
+                    android:defaultValue="true"
+                    android:key="@string/event_default_sharedpref_shown"
+                    android:title="@string/startpage" />
+
+            </androidx.preference.PreferenceCategory>
+
+        </androidx.preference.PreferenceScreen>
+
+        <!-- Update card -->
+        <androidx.preference.PreferenceScreen
+            android:icon="@drawable/ic_download"
+            android:key="card update"
+            android:summary="@string/card_update_summary"
+            android:title="@string/update_note_title">
+
+            <androidx.preference.PreferenceCategory android:title="@string/display">
+
+                <androidx.preference.CheckBoxPreference
+                    android:defaultValue="true"
+                    android:key="@string/update_note_default_sharedpref_shown"
+                    android:title="@string/startpage" />
+
+            </androidx.preference.PreferenceCategory>
+
+        </androidx.preference.PreferenceScreen>
+
+
 
     </androidx.preference.PreferenceCategory>
 

--- a/app/src/main/res/xml/settings.xml
+++ b/app/src/main/res/xml/settings.xml
@@ -231,6 +231,24 @@
 
         </androidx.preference.PreferenceScreen>
 
+        <!-- Support card -->
+        <androidx.preference.PreferenceScreen
+            android:icon="@drawable/ic_live_help"
+            android:key="Not used but needed to make clickable"
+            android:summary="@string/card_support_summary"
+            android:title="@string/support_us_title">
+
+            <androidx.preference.PreferenceCategory android:title="@string/display">
+
+                <androidx.preference.CheckBoxPreference
+                    android:defaultValue="true"
+                    android:key="@string/support_default_sharedpref_shown"
+                    android:title="@string/startpage" />
+
+            </androidx.preference.PreferenceCategory>
+
+        </androidx.preference.PreferenceScreen>
+
         <!-- News card -->
         <androidx.preference.PreferenceScreen
             android:icon="@drawable/ic_rss"
@@ -279,6 +297,7 @@
         </androidx.preference.PreferenceScreen>
 
         <!-- Chat card -->
+        <!-- not included
         <androidx.preference.PreferenceScreen
             android:icon="@drawable/ic_outline_chat_bubble_outline_24px"
             android:key="card_chat"
@@ -300,6 +319,7 @@
             </androidx.preference.PreferenceCategory>
 
         </androidx.preference.PreferenceScreen>
+        -->
 
         <!-- Eduroam card -->
         <androidx.preference.PreferenceScreen
@@ -312,7 +332,7 @@
 
                 <androidx.preference.CheckBoxPreference
                     android:defaultValue="true"
-                    android:key="card_eduroam_start"
+                    android:key="@string/eduroam_default_sharedpref_shown"
                     android:title="@string/startpage" />
 
                 <androidx.preference.CheckBoxPreference

--- a/app/src/main/res/xml/settings.xml
+++ b/app/src/main/res/xml/settings.xml
@@ -47,7 +47,7 @@
 
                 <androidx.preference.CheckBoxPreference
                     android:defaultValue="true"
-                    android:key="card_cafeteria_start"
+                    android:key="@string/cafeteria_default_sharedpref_shown"
                     android:title="@string/startpage" />
 
                 <androidx.preference.CheckBoxPreference
@@ -153,7 +153,7 @@
 
                 <androidx.preference.CheckBoxPreference
                     android:defaultValue="true"
-                    android:key="card_mvv_start"
+                    android:key="@string/mvv_default_sharedpref_shown"
                     android:title="@string/startpage" />
 
             </androidx.preference.PreferenceCategory>
@@ -196,7 +196,7 @@
 
                 <androidx.preference.CheckBoxPreference
                     android:defaultValue="true"
-                    android:key="card_next_lecture_start"
+                    android:key="@string/next_lecture_default_sharedpref_shown"
                     android:title="@string/startpage" />
 
                 <androidx.preference.CheckBoxPreference
@@ -219,7 +219,7 @@
 
                 <androidx.preference.CheckBoxPreference
                     android:defaultValue="true"
-                    android:key="card_tuition_fee_start"
+                    android:key="@string/tuition_fee_default_sharedpref_shown"
                     android:title="@string/startpage" />
 
                 <androidx.preference.CheckBoxPreference
@@ -260,8 +260,18 @@
 
                 <androidx.preference.CheckBoxPreference
                     android:defaultValue="true"
-                    android:key="card_news_start"
-                    android:title="@string/startpage" />
+                    android:key="@string/news_default_sharedpref_shown"
+                    android:title="@string/startpage_news" />
+
+                <androidx.preference.CheckBoxPreference
+                    android:defaultValue="true"
+                    android:key="@string/top_news_default_sharedpref_shown"
+                    android:title="@string/startpage_top_news" />
+
+                <androidx.preference.CheckBoxPreference
+                    android:defaultValue="true"
+                    android:key="@string/news_film_default_sharedpref_shown"
+                    android:title="@string/startpage_film_news" />
 
                 <androidx.preference.CheckBoxPreference
                     android:defaultValue="false"


### PR DESCRIPTION
## Issue

This fixes the following issue(s):
- Resolves: #1582 

## What it does
This PR rewrites the way Cards handle its discard and alyways hide functionality. It moves all information stored for the card in regards to the discard functionality into one SharedPreference per Card. This shared preference can then be completly wiped when restoring the card. The alyways hide functionality is set in the default SharedPreferences by a key defined in the new CardType enum. This key is stored in the String resource file making it easy to use across the Application and preventing accidental differnces in these keys. The usage of String resource also allows for seamless integration into the Settings.xml ensuring synchronity between the state of the Card. Also settings option for every Card were added because previously there was no way to restore these once alyawys hide was pressed. The CardTypes enum and the combination with the string resource also makes the addition of new Cards less error prone as it is more centralized. The PR also fixes a bug when refreshing the CardView leading to an error when using doAsync from Anko and a crash when using coroutines as mentioned [here](https://github.com/TUM-Dev/Campus-Android/issues/1581#issuecomment-1571176965).

## Why this is useful for all students
This PR fixes the issues mentioned in #1582. Thus enhancing the user experience by restoring the excepted functionality.

