### PR TITLE
Fixes configuration file lint.xml does not exist

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -78,7 +78,7 @@ android {
         checkAllWarnings true
         disable 'GoogleAppIndexingWarning', 'TrulyRandom', 'ContentDescription', 'UnusedIds', 'UnusedResources', 'SelectableText'
         htmlReport false
-        lintConfig file('./gradle/config/lint.xml')
+        lintConfig file('../gradle/config/lint.xml')
     }
 }
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -78,7 +78,7 @@ android {
         checkAllWarnings true
         disable 'GoogleAppIndexingWarning', 'TrulyRandom', 'ContentDescription', 'UnusedIds', 'UnusedResources', 'SelectableText'
         htmlReport false
-        lintConfig file('gradle/config/lint.xml')
+        lintConfig file('./gradle/config/lint.xml')
     }
 }
 


### PR DESCRIPTION
## Issue

This fixes the following issue(s):
- When building either localy or on github as part of the CI/CD the lint.xml file is not found

## Screenshot
![image](https://github.com/TUM-Dev/Campus-Android/assets/45203772/ca7cad43-c2cf-4989-8fe0-950216bb42c6)


## Reason why this happens
The path to the lint.xml file is defined in the app build.gradle. Because the lint.xml file is located outside of the app module the `../` is needed to correctly specifiy its path as the app module has to be escaped first.
![image](https://github.com/TUM-Dev/Campus-Android/assets/45203772/4d13d79d-e376-449e-9580-b0c850585e78)

## Why this is useful for all students
Enables the linter to correctly function. Although this is not noticed by students it is definetly usefull for development and it also reduces warnings in the build process.


